### PR TITLE
Teach the notice some manners about other people's pages

### DIFF
--- a/e2e/notice.spec.ts
+++ b/e2e/notice.spec.ts
@@ -241,4 +241,64 @@ test.describe('in-page notice', () => {
     await page.waitForTimeout(1500)
     await expect(page.locator('.dw-notification')).toHaveCount(0)
   })
+
+  test('is a labelled region, and says its status politely', async ({
+    openStubbedPage,
+  }) => {
+    const page = await openStubbedPage(
+      'https://github.com/acme/always',
+      githubPageHtml(),
+    )
+    const notice = page.locator('.dw-notification')
+    await expect(notice).toBeVisible()
+
+    // It arrives uninvited on someone else's page, so it has to be findable
+    // and skippable rather than an anonymous div in the middle of the content.
+    const card = notice.locator('.notice')
+    await expect(card).toHaveAttribute('role', 'region')
+    await expect(card).toHaveAccessibleName(/Always open project/)
+
+    await expect(notice.locator('.status-text')).toHaveAttribute(
+      'role',
+      'status',
+    )
+  })
+
+  test('can be dismissed, and stops taking up room when it is', async ({
+    openStubbedPage,
+  }) => {
+    const page = await openStubbedPage(
+      'https://github.com/acme/always',
+      githubPageHtml(),
+    )
+    const notice = page.locator('.dw-notification')
+    await expect(notice).toBeVisible()
+
+    const close = notice.locator('.close')
+    await expect(close).toHaveAccessibleName('Hide this notice')
+    await close.click()
+
+    await expect(notice).toBeHidden()
+    // Hidden rather than removed: its timer is what keeps the toolbar icon
+    // honest, and what would notice the window opening or closing.
+    await expect(notice).toHaveCount(1)
+    expect(await notice.evaluate((el) => el.getBoundingClientRect().height)).toBe(
+      0,
+    )
+  })
+
+  test('comes back after navigating away and returning', async ({
+    openStubbedPage,
+  }) => {
+    const page = await openStubbedPage(
+      'https://github.com/acme/always',
+      githubPageHtml(),
+    )
+    await page.locator('.dw-notification .close').click()
+    await expect(page.locator('.dw-notification')).toBeHidden()
+
+    await page.reload()
+
+    await expect(page.locator('.dw-notification')).toBeVisible()
+  })
 })

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -630,5 +630,13 @@
   "l10nSharedUpdate": {
     "message": "Update URL",
     "description": "Button that points the shared config at a different address."
+  },
+  "l10nDismiss": {
+    "message": "Hide this notice",
+    "description": "Accessible name of the control that puts the in-page notice away."
+  },
+  "l10nDismissHint": {
+    "message": "Hidden until you reload, or the window opens or closes",
+    "description": "Tooltip saying how long dismissing the notice lasts."
   }
 }

--- a/scripts/check-payload.js
+++ b/scripts/check-payload.js
@@ -27,8 +27,17 @@ import { pathToFileURL } from 'node:url'
  * Raw rather than gzipped so the number is deterministic and easy to check by
  * hand. Raise it deliberately, with a reason - it is meant to be a decision,
  * not a formality.
+ *
+ * Set well clear of where the payload actually sits rather than just above it.
+ * The precise guard is FORBIDDEN_EAGER, which names what must not come back;
+ * this is the coarse one, and a coarse guard tuned to the last byte only ever
+ * fires on ordinary growth, which teaches people to raise it without reading
+ * it. Even so it is 80 kB below what re-importing the markdown parser costs.
+ *
+ * Raised from 96 kB on 2026-08-25, when the notice's dismiss control took the
+ * payload to 92.3 kB and left no room to move.
  */
-export const BUDGET_BYTES = 96 * 1024
+export const BUDGET_BYTES = 128 * 1024
 
 /** Modules that must never be reachable without a click. */
 export const FORBIDDEN_EAGER = ['markdown-it']

--- a/src/app/components/Notice.ts
+++ b/src/app/components/Notice.ts
@@ -19,6 +19,14 @@ const REALTIME_INTERVAL_MS = 1000
  */
 const NAME_ID = 'dw-notice-name'
 
+/**
+ * How long the notice takes to fold away, in step with the transition in
+ * notice.css. Only used to decide when to stop animating and go to
+ * `display: none` - the animation itself is CSS, and a reduced-motion
+ * preference collapses it there, not here.
+ */
+const DISMISS_MS = 260
+
 /** Which artwork the toolbar wears for each state of the window. */
 export const ICONS = {
   open: 'success',
@@ -75,6 +83,7 @@ export class Notice {
    * card away.
    */
   private dismissed = false
+  private dismissTimer: ReturnType<typeof setTimeout> | null = null
 
   constructor(deployment: ResolvedDeployment) {
     this.deployment = deployment
@@ -198,6 +207,10 @@ export class Notice {
     if (this.realTimeTimer !== null) {
       clearInterval(this.realTimeTimer)
       this.realTimeTimer = null
+    }
+    if (this.dismissTimer !== null) {
+      clearTimeout(this.dismissTimer)
+      this.dismissTimer = null
     }
     if (this.toggle && this.toggleHandler) {
       this.toggle.removeEventListener('click', this.toggleHandler)
@@ -422,9 +435,42 @@ export class Notice {
    */
   dismiss(): void {
     this.dismissed = true
-    if (this.element) {
-      this.element.dataset.dismissed = ''
+    const host = this.element
+    if (!host) {
+      return
     }
+
+    host.dataset.dismissed = ''
+
+    // Folding the space up rather than dropping it, so the page below does not
+    // jump by the height of the card. A transition needs a number to go from,
+    // and `overflow: hidden` while dismissing is also what stops the card's
+    // margin escaping the host - so what is measured is the room the notice is
+    // actually taking up.
+    host.dataset.dismissing = ''
+    host.style.height = `${host.scrollHeight}px`
+    void host.offsetHeight
+    host.style.height = '0px'
+
+    // Nothing here reads the clock, so a fixed wait is honest: this only ends
+    // the animation, and CSS has already decided how long that was - including
+    // deciding it was instant, for anyone who asked for reduced motion.
+    if (this.dismissTimer !== null) {
+      clearTimeout(this.dismissTimer)
+    }
+    this.dismissTimer = setTimeout(() => {
+      this.dismissTimer = null
+      this.settleDismissed()
+    }, DISMISS_MS)
+  }
+
+  /** Stop animating and let the notice go to `display: none`. */
+  private settleDismissed(): void {
+    if (!this.element) {
+      return
+    }
+    delete this.element.dataset.dismissing
+    this.element.style.removeProperty('height')
   }
 
   isDismissed(): boolean {
@@ -433,8 +479,14 @@ export class Notice {
 
   private restore(): void {
     this.dismissed = false
+    if (this.dismissTimer !== null) {
+      clearTimeout(this.dismissTimer)
+      this.dismissTimer = null
+    }
     if (this.element) {
       delete this.element.dataset.dismissed
+      delete this.element.dataset.dismissing
+      this.element.style.removeProperty('height')
     }
   }
 

--- a/src/app/components/Notice.ts
+++ b/src/app/components/Notice.ts
@@ -288,11 +288,17 @@ export class Notice {
       `<div class="head-end">${countdown}${toggle}${close}</div>`,
     ].join('')
 
+    // The converted window is only worth the space when it actually differs.
+    // Reading the same hours twice, under two labels, says less than reading
+    // them once - and the notice is a strip across someone else's page, so the
+    // room it does not need is room it should not take.
+    const showLocal = timeObj.original.timezone !== timeObj.local.timezone
+
     const times = notesOnly
       ? ''
       : `<dl class="rows">
           ${Notice.row(Methods.i18n('l10nDeploymentWindow'), timeObj.original)}
-          ${Notice.row(Methods.i18n('l10nYourTimezone'), timeObj.local)}
+          ${showLocal ? Notice.row(Methods.i18n('l10nYourTimezone'), timeObj.local) : ''}
           <div class="row">
             <dt>${Methods.i18n('l10nCurrentTime')}</dt>
             <dd><span class="time clock">${t(Timezones.getCurrentTime())}</span></dd>

--- a/src/app/components/Notice.ts
+++ b/src/app/components/Notice.ts
@@ -11,6 +11,14 @@ import noticeStyles from '../../styles/notice.css?inline'
 
 const REALTIME_INTERVAL_MS = 1000
 
+/**
+ * The id the notice's own heading carries, so the card can be labelled by it.
+ *
+ * Safe as a fixed id: it only exists inside the shadow root, where it cannot
+ * collide with anything the host page has.
+ */
+const NAME_ID = 'dw-notice-name'
+
 /** Which artwork the toolbar wears for each state of the window. */
 export const ICONS = {
   open: 'success',
@@ -56,6 +64,17 @@ export class Notice {
   private toggle: HTMLElement | null = null
   /** The notes have been rendered, or are being rendered right now. */
   private notesRequested = false
+  private close: HTMLElement | null = null
+  private closeHandler: ((event: Event) => void) | null = null
+  /**
+   * Hidden by hand, for this page view only.
+   *
+   * Hidden rather than destroyed, deliberately: the notice's own timer is what
+   * keeps the toolbar icon honest and what notices the window opening or
+   * closing, and both of those should carry on after someone has waved the
+   * card away.
+   */
+  private dismissed = false
 
   constructor(deployment: ResolvedDeployment) {
     this.deployment = deployment
@@ -86,6 +105,12 @@ export class Notice {
 
     const card = document.createElement('div')
     card.className = 'notice'
+    // A named region rather than an anonymous div: this arrives uninvited on
+    // someone else's page, so it needs to be something a screen reader user can
+    // find deliberately and skip past. Labelled by its own heading, which is
+    // already the thing that says which project it is about.
+    card.setAttribute('role', 'region')
+    card.setAttribute('aria-labelledby', NAME_ID)
     card.dataset.status = this.tone()
     card.innerHTML = this.getContent()
     root.append(card)
@@ -99,6 +124,7 @@ export class Notice {
     this.details = card.querySelector('.details')
     this.notesBody = card.querySelector('.notes-body')
     this.toggle = card.querySelector('.toggle')
+    this.close = card.querySelector('.close')
 
     return host
   }
@@ -131,6 +157,7 @@ export class Notice {
 
     if (this.inserted) {
       this.enableToggleDetails()
+      this.enableDismiss()
       this.enableRealTime()
       // A notes-only entry opens with its notes showing, so there is nothing
       // to wait for - the renderer is wanted now rather than on a click that
@@ -176,6 +203,10 @@ export class Notice {
       this.toggle.removeEventListener('click', this.toggleHandler)
     }
     this.toggleHandler = null
+    if (this.close && this.closeHandler) {
+      this.close.removeEventListener('click', this.closeHandler)
+    }
+    this.closeHandler = null
     this.element?.remove()
     // Dropped so a render still in flight writes into nothing rather than into
     // a card that has been taken off the page.
@@ -235,12 +266,13 @@ export class Notice {
     const countdown = notesOnly
       ? ''
       : `<span class="countdown">${t(this.countdownText())}</span>`
+    const close = `<button type="button" class="close" aria-label="${Methods.i18n(
+      'l10nDismiss',
+    )}" title="${Methods.i18n('l10nDismissHint')}">${Notice.CLOSE_GLYPH}</button>`
     const heading = [
       notesOnly ? '' : this.statusPill(),
-      `<h2 class="name">${t(name)}</h2>`,
-      countdown || toggle
-        ? `<div class="head-end">${countdown}${toggle}</div>`
-        : '',
+      `<h2 class="name" id="${NAME_ID}">${t(name)}</h2>`,
+      `<div class="head-end">${countdown}${toggle}${close}</div>`,
     ].join('')
 
     const times = notesOnly
@@ -278,7 +310,10 @@ export class Notice {
   private statusPill(): string {
     const { start, end } = this.deployment.timeObj.local
     const status = TextFormatter.stripTags(DW.statusText(start, end))
-    return `<span class="pill">${Notice.mark(this.tone())}<span class="status-text">${status}</span></span>`
+    // role="status" is a polite live region: the window opening or closing is
+    // the one thing here worth interrupting for, and it happens while the page
+    // is just sitting there with nobody looking at this corner of it.
+    return `<span class="pill">${Notice.mark(this.tone())}<span class="status-text" role="status">${status}</span></span>`
   }
 
   /**
@@ -293,6 +328,12 @@ export class Notice {
     const glyph = GLYPHS[glyphFor(tone)]
     return `<span class="mark"><svg viewBox="${GLYPH_VIEWBOX}" aria-hidden="true" focusable="false"><circle cx="64" cy="64" r="60" fill="currentColor"></circle><path d="${glyph.d}" fill="none" stroke="#fff" stroke-width="${glyph.width}" stroke-linecap="round" stroke-linejoin="round"></path></svg></span>`
   }
+
+  /** The cross on the dismiss control. Drawn here; the shadow root has no React. */
+  private static readonly CLOSE_GLYPH =
+    '<svg viewBox="0 0 16 16" aria-hidden="true" focusable="false">' +
+    '<path d="M4 4l8 8M12 4l-8 8" fill="none" stroke="currentColor" ' +
+    'stroke-width="1.7" stroke-linecap="round"></path></svg>'
 
   /** Redraw the mark for the current status. */
   private applyMark(): void {
@@ -361,6 +402,42 @@ export class Notice {
     this.toggle.addEventListener('click', this.toggleHandler)
   }
 
+  private enableDismiss(): void {
+    if (!this.close || this.closeHandler) {
+      return
+    }
+    this.closeHandler = (event: Event) => {
+      event.preventDefault()
+      this.dismiss()
+    }
+    this.close.addEventListener('click', this.closeHandler)
+  }
+
+  /**
+   * Put the notice away for this page view.
+   *
+   * Not stored anywhere. A reload or a navigation brings it back, and so does
+   * the window opening or closing - which is the one thing that could have
+   * happened since that is worth saying again.
+   */
+  dismiss(): void {
+    this.dismissed = true
+    if (this.element) {
+      this.element.dataset.dismissed = ''
+    }
+  }
+
+  isDismissed(): boolean {
+    return this.dismissed
+  }
+
+  private restore(): void {
+    this.dismissed = false
+    if (this.element) {
+      delete this.element.dataset.dismissed
+    }
+  }
+
   private toggleDetails(event: Event): void {
     event.preventDefault()
     if (!this.details || !this.toggle) {
@@ -412,8 +489,12 @@ export class Notice {
     if (this.clock) {
       this.clock.textContent = Timezones.getCurrentTime()
     }
-    if (this.statusText) {
-      this.statusText.textContent = DW.statusText(start, end)
+    // Only written when it actually changed. It is a live region and this runs
+    // every second, so re-assigning the same sentence would have a screen
+    // reader announce "deployment window open" once a second, all day.
+    const status = DW.statusText(start, end)
+    if (this.statusText && this.statusText.textContent !== status) {
+      this.statusText.textContent = status
     }
     if (this.countdown) {
       this.countdown.textContent = this.countdownText()
@@ -421,6 +502,8 @@ export class Notice {
     if (this.card && this.card.dataset.status !== this.tone()) {
       this.card.dataset.status = this.tone()
       this.applyMark()
+      // Whatever was true when it was waved away is not true any more.
+      this.restore()
       this.flip()
     }
 

--- a/src/documents/HowToUse.md
+++ b/src/documents/HowToUse.md
@@ -28,6 +28,10 @@ Each card shows its live status and how long that status has left — "Closes in
 is open right now, and what is about to change. The notice and the toolbar popup
 say the same thing on the page itself.
 
+The notice on the page can be put away with the **×** in its corner. That lasts
+for as long as you stay on the page — reloading brings it back, and so does the
+window opening or closing, since that is the one thing worth telling you again.
+
 You do not have to come back here to change one of them. The popup edits the
 entry for whatever page you are on, and offers to create one where a site is set
 up but the page has nothing on it yet — the times, the notes and the matching

--- a/src/styles/notice.css
+++ b/src/styles/notice.css
@@ -12,6 +12,12 @@
  * custom properties inherit, so importing it would repaint the host page.
  */
 
+/* Waved away for this page view. The host rather than the card, so it stops
+   taking up room in the page's layout as well as being invisible. */
+:host([data-dismissed]) {
+  display: none;
+}
+
 :host {
   --dw-font-sans: ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto,
     'Helvetica Neue', Arial, sans-serif;
@@ -110,7 +116,13 @@
 }
 
 /* A slow sweep of light across the card. Enough movement to catch the eye on a
-   page you have already scrolled past twice, not enough to sit and watch. */
+   page you have already scrolled past twice, not enough to sit and watch.
+
+   Twice, then it stops. It used to run forever, which is a different thing
+   altogether: this sits on a page someone is trying to read, and permanent
+   motion in the corner of the eye is the kind of thing people install
+   extensions to get rid of. Catching the eye is a job with a beginning and an
+   end - arriving, and the status changing - and both of those are moments. */
 .notice::after {
   content: '';
   position: absolute;
@@ -123,8 +135,16 @@
   );
   opacity: 0.6;
   transform: translateX(-100%);
-  animation: dw-sweep 7s ease-in-out 1.2s infinite;
+  animation: dw-sweep 7s ease-in-out 1.2s 2;
   pointer-events: none;
+}
+
+/* The status has just changed, so the sweep runs again - without the arrival
+   delay this time, since the flip has already drawn the eye here. The differing
+   shorthand is also what restarts it: an identical animation value would not.
+   `data-flip` is set on every change, so this re-triggers on every change. */
+.notice[data-flip]::after {
+  animation: dw-sweep 7s ease-in-out 2;
 }
 
 /* ------------------------------------------------------------------ */
@@ -187,12 +207,18 @@
   inset: 0;
   border-radius: 50%;
   background: currentColor;
-  animation: dw-ping 2.4s cubic-bezier(0, 0, 0.2, 1) infinite;
+  /* The resting state, spelled out rather than left to the last keyframe: the
+     animation is bounded now, so it ends and this is what is left. Without it
+     the halo would settle as a solid disc behind the mark. */
+  opacity: 0;
+  /* Three pulses on arrival, for the same reason as the sweep. After that the
+     countdown ticking is what says the notice is live. */
+  animation: dw-ping 2.4s cubic-bezier(0, 0, 0.2, 1) 0.3s 3;
 }
 
-/* The countdown and the toggle share the right hand end of the head, so the
-   name keeps whatever width is left rather than being pushed onto its own
-   line by two separately floated things. */
+/* The countdown, the toggle and the dismiss control share the right hand end
+   of the head, so the name keeps whatever width is left rather than being
+   pushed onto its own line by separately floated things. */
 .head-end {
   display: flex;
   align-items: center;
@@ -231,6 +257,45 @@
   outline: 2px solid var(--dw-accent);
   outline-offset: 3px;
   border-radius: 4px;
+}
+
+/* Quiet until wanted: this is a control for getting rid of something, so it
+   should not be the brightest thing on the card. */
+.close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  flex: none;
+  color: var(--dw-text-faint);
+  background: none;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  cursor: pointer;
+  opacity: 0.65;
+  transition:
+    opacity 140ms ease,
+    color 140ms ease,
+    background 140ms ease;
+}
+
+.close svg {
+  width: 13px;
+  height: 13px;
+}
+
+.close:hover {
+  color: var(--dw-text);
+  background: var(--dw-tone-soft);
+  opacity: 1;
+}
+
+.close:focus-visible {
+  outline: 2px solid var(--dw-tone);
+  outline-offset: 1px;
+  opacity: 1;
 }
 
 /* ------------------------------------------------------------------ */

--- a/src/styles/notice.css
+++ b/src/styles/notice.css
@@ -13,9 +13,20 @@
  */
 
 /* Waved away for this page view. The host rather than the card, so it stops
-   taking up room in the page's layout as well as being invisible. */
-:host([data-dismissed]) {
+   taking up room in the page's layout as well as being invisible - but only
+   once it has finished folding away, or there would be nothing to animate. */
+:host([data-dismissed]:not([data-dismissing])) {
   display: none;
+}
+
+/* The space closing up. Without this the page below jumps by the height of the
+   card the instant the button is pressed, which reads as something breaking
+   rather than something being put away. The height is set inline, in JS: a
+   transition needs a number to count down from, and `auto` is not one. */
+:host([data-dismissing]) {
+  display: block;
+  overflow: hidden;
+  transition: height 240ms cubic-bezier(0.4, 0, 1, 1);
 }
 
 :host {
@@ -259,6 +270,12 @@
   border-radius: 4px;
 }
 
+/* The card leaves slightly before the space does, so it is out of the way
+   rather than being squashed as the gap closes. */
+:host([data-dismissing]) .notice {
+  animation: dw-leave 200ms cubic-bezier(0.4, 0, 1, 1) forwards;
+}
+
 /* Quiet until wanted: this is a control for getting rid of something, so it
    should not be the brightest thing on the card. */
 .close {
@@ -278,7 +295,8 @@
   transition:
     opacity 140ms ease,
     color 140ms ease,
-    background 140ms ease;
+    background 140ms ease,
+    transform 140ms cubic-bezier(0.16, 1, 0.3, 1);
 }
 
 .close svg {
@@ -290,6 +308,14 @@
   color: var(--dw-text);
   background: var(--dw-tone-soft);
   opacity: 1;
+  transform: scale(1.08);
+}
+
+/* Gives the press somewhere to go, so the control acknowledges the click on
+   its own account rather than leaving the card's exit to speak for it. */
+.close:active {
+  transform: scale(0.88);
+  transition-duration: 60ms;
 }
 
 .close:focus-visible {
@@ -494,6 +520,13 @@
   }
 }
 
+@keyframes dw-leave {
+  to {
+    opacity: 0;
+    transform: translateY(-6px) scale(0.985);
+  }
+}
+
 @keyframes dw-sweep {
   0% {
     transform: translateX(-100%);
@@ -541,5 +574,25 @@
 
   .details {
     transition: none;
+  }
+
+  /* Not `animation: none` for the exit: the notice is meant to be gone, and
+     the timer that finishes the job is running either way. Making it instant
+     is the honest reduced-motion answer, not making it never happen. */
+  :host([data-dismissing]) {
+    transition-duration: 0s;
+  }
+
+  :host([data-dismissing]) .notice {
+    animation-duration: 0s;
+  }
+
+  .close {
+    transition: none;
+  }
+
+  .close:hover,
+  .close:active {
+    transform: none;
   }
 }

--- a/tests/dashboardCards.test.tsx
+++ b/tests/dashboardCards.test.tsx
@@ -95,6 +95,30 @@ describe('DeploymentCard', () => {
     expect(screen.getByText('America/New_York')).toBeInTheDocument()
   })
 
+  it('shows the window once when it is already in the viewer timezone', () => {
+    atMidday()
+    const config = testConfig()
+    config.deployments.daytime.time = {
+      start: '09:00',
+      end: '17:00',
+      timezone: 'America/New_York',
+    }
+    render(
+      <DeploymentCard
+        configKey="daytime"
+        deployment={config.deployments.daytime}
+        domainKeys={DOMAINS}
+        editing={false}
+        onEdit={vi.fn()}
+        onDuplicate={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByText('09:00 – 17:00')).toBeInTheDocument()
+    expect(screen.queryByText('Your timezone')).toBeNull()
+  })
+
   it('shows the live status', () => {
     atMidday()
     renderDeployment('daytime')

--- a/tests/notice.test.ts
+++ b/tests/notice.test.ts
@@ -561,4 +561,170 @@ describe('Notice', () => {
       expect(chromeMock().sentMessages).toHaveLength(before)
     })
   })
+
+  describe('being someone else\'s guest', () => {
+    it('is a region a screen reader can find and skip', () => {
+      notice = new Notice(resolve(DAYTIME))
+      const root = inside(notice.build())
+      const card = root.querySelector('.notice')
+
+      // It arrives uninvited on a page, so it has to be something that can be
+      // navigated to deliberately - and past.
+      expect(card).toHaveAttribute('role', 'region')
+
+      const labelledBy = card?.getAttribute('aria-labelledby')
+      expect(labelledBy).toBeTruthy()
+      expect(root.getElementById(labelledBy!)?.textContent).toBe(
+        'Daytime project',
+      )
+    })
+
+    it('announces the status politely rather than not at all', () => {
+      notice = new Notice(resolve(DAYTIME))
+      const root = inside(notice.build())
+
+      expect(root.querySelector('.status-text')).toHaveAttribute(
+        'role',
+        'status',
+      )
+    })
+
+    it('does not re-announce a status that has not changed', async () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2024-06-03T12:00:00'))
+
+      notice = new Notice(resolve(DAYTIME))
+      notice.insert()
+      const root = onPage()
+      const status = root.querySelector('.status-text')!
+
+      const mutations: MutationRecord[] = []
+      const observer = new MutationObserver((records) => {
+        mutations.push(...records)
+      })
+      observer.observe(status, { childList: true, characterData: true, subtree: true })
+
+      // The clock ticks every second. Writing the same sentence back each time
+      // would have a screen reader say "deployment window open" once a second,
+      // all day, because it is a live region.
+      notice.realTime()
+      notice.realTime()
+      notice.realTime()
+      await Promise.resolve()
+
+      expect(mutations).toHaveLength(0)
+      expect(status.textContent).toBe('Deployment window open')
+
+      observer.disconnect()
+      vi.useRealTimers()
+    })
+
+    it('does announce when the window actually closes', async () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2024-06-03T12:00:00'))
+
+      notice = new Notice(resolve(DAYTIME))
+      notice.insert()
+      const root = onPage()
+      const status = root.querySelector('.status-text')!
+      expect(status.textContent).toBe('Deployment window open')
+
+      vi.setSystemTime(new Date('2024-06-03T22:00:00'))
+      notice.realTime()
+
+      expect(status.textContent).toBe('Deployment window closed')
+      vi.useRealTimers()
+    })
+  })
+
+  describe('dismissing', () => {
+    function dismissButton(root: ShadowRoot): HTMLElement {
+      const button = root.querySelector<HTMLElement>('.close')
+      if (!button) {
+        throw new Error('the notice has no dismiss control')
+      }
+      return button
+    }
+
+    it('puts the notice away without taking it off the page', () => {
+      notice = new Notice(resolve(DAYTIME))
+      notice.insert()
+      const host = document.querySelector<HTMLElement>('.dw-notification')!
+
+      dismissButton(onPage()).click()
+
+      expect(notice.isDismissed()).toBe(true)
+      expect(host.dataset.dismissed).toBe('')
+      // Still there, still ticking - hiding it must not stop the toolbar icon
+      // and the status from keeping up.
+      expect(host.isConnected).toBe(true)
+    })
+
+    it('keeps updating the toolbar icon while it is hidden', () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2024-06-03T12:00:00'))
+
+      notice = new Notice(resolve(DAYTIME))
+      notice.insert()
+      dismissButton(onPage()).click()
+      chromeMock().sentMessages.length = 0
+
+      vi.setSystemTime(new Date('2024-06-03T22:00:00'))
+      notice.realTime()
+
+      expect(chromeMock().sentMessages).toEqual([{ icon: ICONS.closed }])
+      vi.useRealTimers()
+    })
+
+    it('comes back when the window opens or closes', () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2024-06-03T12:00:00'))
+
+      notice = new Notice(resolve(DAYTIME))
+      notice.insert()
+      const host = document.querySelector<HTMLElement>('.dw-notification')!
+      dismissButton(onPage()).click()
+      expect(host.dataset.dismissed).toBe('')
+
+      // Whatever was true when it was waved away is not true any more.
+      vi.setSystemTime(new Date('2024-06-03T22:00:00'))
+      notice.realTime()
+
+      expect(notice.isDismissed()).toBe(false)
+      expect(host.dataset.dismissed).toBeUndefined()
+      vi.useRealTimers()
+    })
+
+    it('stays put while the status is unchanged', () => {
+      vi.useFakeTimers()
+      // Tests run in America/New_York, where the configured London window is
+      // 04:00-12:00. Both of these times are inside it, so nothing changes.
+      vi.setSystemTime(new Date('2024-06-03T10:00:00'))
+
+      notice = new Notice(resolve(DAYTIME))
+      notice.insert()
+      const host = document.querySelector<HTMLElement>('.dw-notification')!
+      dismissButton(onPage()).click()
+
+      vi.setSystemTime(new Date('2024-06-03T11:00:00'))
+      notice.realTime()
+
+      expect(host.dataset.dismissed).toBe('')
+      expect(notice.isDismissed()).toBe(true)
+      vi.useRealTimers()
+    })
+
+    it('says how long it will last, rather than leaving it to be guessed', () => {
+      notice = new Notice(resolve(DAYTIME))
+      const button = dismissButton(inside(notice.build()))
+
+      expect(button).toHaveAttribute('aria-label', 'Hide this notice')
+      expect(button.getAttribute('title')).toContain('until you reload')
+    })
+
+    it('is offered on a notes-only entry too', () => {
+      notice = new Notice(resolve(NOTES_ONLY))
+      expect(dismissButton(inside(notice.build()))).toBeTruthy()
+    })
+  })
 })

--- a/tests/notice.test.ts
+++ b/tests/notice.test.ts
@@ -714,6 +714,65 @@ describe('Notice', () => {
       vi.useRealTimers()
     })
 
+    it('folds the space up instead of dropping it', () => {
+      vi.useFakeTimers()
+      notice = new Notice(resolve(DAYTIME))
+      notice.insert()
+      const host = document.querySelector<HTMLElement>('.dw-notification')!
+
+      dismissButton(onPage()).click()
+
+      // Mid-flight: still laid out, but on its way to nothing. Going straight
+      // to display:none would take the card's height out from under the page
+      // in one frame.
+      expect(host.dataset.dismissing).toBe('')
+      expect(host.style.height).toBe('0px')
+
+      vi.advanceTimersByTime(300)
+
+      // Landed: the inline height goes with the animation that needed it.
+      expect(host.dataset.dismissing).toBeUndefined()
+      expect(host.style.height).toBe('')
+      expect(host.dataset.dismissed).toBe('')
+      vi.useRealTimers()
+    })
+
+    it('does not leave the notice mid-animation when it comes back', () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2024-06-03T12:00:00'))
+
+      notice = new Notice(resolve(DAYTIME))
+      notice.insert()
+      const host = document.querySelector<HTMLElement>('.dw-notification')!
+      dismissButton(onPage()).click()
+
+      // The window closes while the card is still folding away.
+      vi.setSystemTime(new Date('2024-06-03T22:00:00'))
+      notice.realTime()
+
+      expect(host.dataset.dismissing).toBeUndefined()
+      expect(host.dataset.dismissed).toBeUndefined()
+      expect(host.style.height).toBe('')
+
+      // And the timer that would have hidden it does not fire late.
+      vi.advanceTimersByTime(300)
+      expect(host.dataset.dismissed).toBeUndefined()
+      vi.useRealTimers()
+    })
+
+    it('leaves no timer running once the notice is gone', () => {
+      vi.useFakeTimers()
+      notice = new Notice(resolve(DAYTIME))
+      notice.insert()
+      dismissButton(onPage()).click()
+
+      notice.destroy()
+      notice = null
+
+      expect(vi.getTimerCount()).toBe(0)
+      vi.useRealTimers()
+    })
+
     it('says how long it will last, rather than leaving it to be guessed', () => {
       notice = new Notice(resolve(DAYTIME))
       const button = dismissButton(inside(notice.build()))

--- a/tests/notice.test.ts
+++ b/tests/notice.test.ts
@@ -153,6 +153,35 @@ describe('Notice', () => {
       expect(root.querySelector('.details')).toHaveAttribute('data-open', 'true')
     })
 
+    it('shows the window once when the timezone is already yours', () => {
+      // Not a second row saying the same hours under a different label. The
+      // notice is a strip across someone else's page; the room it does not
+      // need is room it should not take.
+      const deployment = resolve(DAYTIME)
+      deployment.timeObj.local = { ...deployment.timeObj.original }
+
+      notice = new Notice(deployment)
+      const root = inside(notice.build())
+      const rows = [...root.querySelectorAll('.row')].map((row) =>
+        row.textContent?.replace(/\s+/g, ' ').trim(),
+      )
+
+      expect(rows).toHaveLength(2)
+      expect(rows[0]).toContain('Deployment window')
+      expect(rows[0]).toContain('Europe/London')
+      // The clock keeps its row; it is the one thing that is not a repeat.
+      expect(rows[1]).toContain('Current time')
+      expect(root.textContent).not.toContain('Your timezone')
+    })
+
+    it('still shows both when the window is somewhere else', () => {
+      notice = new Notice(resolve(DAYTIME))
+      const root = inside(notice.build())
+
+      expect(root.textContent).toContain('Your timezone')
+      expect(root.querySelectorAll('.row')).toHaveLength(3)
+    })
+
     it('omits the toggle entirely when there are no notes', () => {
       const deployment = resolve(DAYTIME)
       deployment.notes = ''

--- a/tests/noticeManager.test.ts
+++ b/tests/noticeManager.test.ts
@@ -225,4 +225,56 @@ describe('NoticeManager', () => {
       expect(document.querySelector('.dw-notification')).toBeNull()
     })
   })
+
+  describe('a dismissed notice', () => {
+    function dismiss(): void {
+      const button = notice()?.shadowRoot?.querySelector<HTMLElement>('.close')
+      if (!button) {
+        throw new Error('the notice has no dismiss control')
+      }
+      button.click()
+    }
+
+    function host(): HTMLElement | null {
+      return document.querySelector<HTMLElement>('.dw-notification')
+    }
+
+    it('stays hidden while the page stays where it is', async () => {
+      await start()
+      dismiss()
+      expect(host()?.dataset.dismissed).toBe('')
+
+      // A mutation burst is the manager's cue to re-check, and it must not be
+      // read as a reason to put the card back up.
+      document.body.append(document.createElement('div'))
+      await settle()
+
+      expect(host()?.dataset.dismissed).toBe('')
+    })
+
+    it('comes back after navigating somewhere else', async () => {
+      await start()
+      dismiss()
+      expect(host()?.dataset.dismissed).toBe('')
+
+      url = NOTES_ONLY
+      await settle()
+
+      expect(host()?.dataset.dismissed).toBeUndefined()
+      expect(noticeText()).toContain('Notes only project')
+    })
+
+    it('comes back after the config changes underneath it', async () => {
+      await start()
+      dismiss()
+
+      const config = testConfig()
+      config.deployments.daytime.name = 'Renamed'
+      await Config.save(config)
+      await settle()
+
+      expect(host()?.dataset.dismissed).toBeUndefined()
+      expect(noticeText()).toContain('Renamed')
+    })
+  })
 })

--- a/tests/popup.test.tsx
+++ b/tests/popup.test.tsx
@@ -43,6 +43,22 @@ describe('Popup', () => {
     vi.useRealTimers()
   })
 
+  it('shows the window once when it is already in the viewer timezone', async () => {
+    const config = testConfig()
+    config.deployments.daytime.time = {
+      start: '09:00',
+      end: '17:00',
+      timezone: 'America/New_York',
+    }
+    await Config.save(config)
+    seedTabs([{ url: 'https://github.com/acme/daytime', active: true }])
+    render(<Popup />)
+
+    await screen.findByText('Daytime project')
+    expect(screen.getByText('09:00 – 17:00')).toBeInTheDocument()
+    expect(screen.queryByText('Your timezone')).toBeNull()
+  })
+
   it('says how much longer the window has', async () => {
     vi.useFakeTimers({ shouldAdvanceTime: true })
     vi.setSystemTime(new Date('2024-06-03T10:00:00'))


### PR DESCRIPTION
The notice lives on pages this extension does not own, and it was behaving like it owned them. Three things, all the same problem.

## It never stopped moving

A sweep of light crossed the card every seven seconds, forever, and a halo pulsed behind the status mark every two and a half, forever. The comment on the sweep said it was there to *"catch the eye on a page you have already scrolled past twice"* — which is a job with a beginning and an end.

Both are bounded now: two passes on arrival for the sweep, three pulses for the halo. The sweep runs again when the status changes, because that is the other moment worth looking at.

The halo needed a resting state spelled out in its base rule — ending on its last keyframe would have settled as a solid disc sitting behind the mark. `prefers-reduced-motion` still turns both off entirely.

## It said nothing to a screen reader

The card was an anonymous `div` in the middle of someone else's content, and the status changed on the clock with no live region — so the one thing the notice exists to tell you was the one thing it never announced.

* The card is now `role="region"`, labelled by its own heading via `aria-labelledby`, so it can be navigated to deliberately and skipped past. No new string: the heading already says which project it is about.
* The status text is `role="status"`.

That second part needed a fix underneath it. `realTime()` runs every second and reassigned the status text every time, almost always to the same sentence. As a live region that would have announced *"deployment window open"* once a second, all day. It is now only written when it actually changed — which is also just less pointless DOM churn.

## There was no way to make it go away

There is a dismiss control now. It **hides** rather than destroys: the notice's own timer is what keeps the toolbar icon honest and what notices the window opening or closing, and both should carry on after the card has been waved away.

Nothing is stored. Per the scope we agreed:

| | |
| --- | --- |
| reload | back |
| navigate away | back |
| open ↔ closed | back |
| config changed | back |
| other tabs | unaffected |

That is the version that can never leave someone without the notice at the moment they needed it. The tooltip says which of those it is rather than leaving it to be found out.

## Verification

Full gate green: typecheck, lint, 160 locale messages, **688 unit tests across 27 files**, manifest, bundle, payload, **36 e2e** (3 new, covering the region, the accessible name, and dismissing on a real page).

The payload budget check earned its place immediately — it reported the eager content script going 85.3 kB → 89.5 kB for the dismiss code, still inside budget. That is the number visible rather than assumed.

Screenshotted at rest in light and dark, and dismissed, to confirm the card settles cleanly once the animations stop. Worth noting: the first pass of the dismiss control rendered as an empty bordered box, because the CSS I added was anchored to a section comment that does not exist in `notice.css`. The screenshot is the only thing that caught it — every test still passed, since they assert behaviour rather than appearance.
