### PR TITLE
Let a window know which days it opens on

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ is showing, or a new one for a page that has none yet, so a wrong window can be
 corrected from where it was noticed. It follows the light/dark choice made on
 the options page, and can be switched from its own footer.
 
+A window can be limited to **certain days** — "Mon–Fri", or "Mon, Wed, Fri".
+A day is when the window *opens*, so an overnight window belongs to the day it
+starts on, and the days move with the hours when the window is written in
+another timezone. When the next one is days away the countdown says "Opens in
+2d 4h" rather than pretending it is tomorrow.
+
 A **shared config** can be pointed at a JSON file on an https address, for a
 team that deploys the same projects to the same windows. It is fetched hourly
 and merged *underneath* everything configured locally, so any single entry can
@@ -177,6 +183,7 @@ src/
     content.ts           Content script entry point
     components/          DW (resolution), Notice (injection), Timezones, helpers
                          Markdown lives here, behind a dynamic import
+                         weekdays.ts is the day-of-week model
     config/              Storage access, types, validation, shared config
     matching/            Chrome match-pattern implementation
   ui/

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -555,6 +555,10 @@
     "message": "under a minute",
     "description": "Duration shown when the window changes state within the current minute."
   },
+  "l10nDaysShort": {
+    "message": "d",
+    "description": "Short suffix for a number of days, as in \"3d 4h\"."
+  },
   "l10nHoursShort": {
     "message": "h",
     "description": "Single letter suffix for hours in a duration, e.g. the h in '2h 10m'."
@@ -638,5 +642,45 @@
   "l10nDismissHint": {
     "message": "Hidden until you reload, or the window opens or closes",
     "description": "Tooltip saying how long dismissing the notice lasts."
+  },
+  "l10nDayMon": {
+    "message": "Mon",
+    "description": "Short label for Monday."
+  },
+  "l10nDayTue": {
+    "message": "Tue",
+    "description": "Short label for Tuesday."
+  },
+  "l10nDayWed": {
+    "message": "Wed",
+    "description": "Short label for Wednesday."
+  },
+  "l10nDayThu": {
+    "message": "Thu",
+    "description": "Short label for Thursday."
+  },
+  "l10nDayFri": {
+    "message": "Fri",
+    "description": "Short label for Friday."
+  },
+  "l10nDaySat": {
+    "message": "Sat",
+    "description": "Short label for Saturday."
+  },
+  "l10nDaySun": {
+    "message": "Sun",
+    "description": "Short label for Sunday."
+  },
+  "l10nDays": {
+    "message": "Days",
+    "description": "Label for the days a deployment window opens on."
+  },
+  "l10nDaysHint": {
+    "message": "Leave all of them on for a window that opens every day. A day is when the window opens, so an overnight window belongs to the day it starts.",
+    "description": "Hint for the day picker."
+  },
+  "l10nDaysRequired": {
+    "message": "Pick at least one day, or the window can never open.",
+    "description": "Error when every day has been unticked."
   }
 }

--- a/src/app/components/DW.ts
+++ b/src/app/components/DW.ts
@@ -7,10 +7,12 @@ import type {
 } from '../config/types'
 import { matchesAny } from '../matching/MatchPattern'
 import { Methods } from './Methods'
-import { Timezones, isValidTimezone } from './Timezones'
+import { Timezones, type WindowSpec, isValidTimezone } from './Timezones'
+import { shiftDays, toWeekdays } from './weekdays'
 
 const DEFAULT_TIME = '00:00'
 const MINUTES_PER_HOUR = 60
+const MINUTES_PER_DAY = 24 * MINUTES_PER_HOUR
 
 /**
  * Resolves "what, if anything, should be shown for this URL".
@@ -125,7 +127,6 @@ export class DW {
     domainKey: string,
   ): ResolvedDeployment {
     const timeObj = DW.buildTimes(deployment)
-    const { start, end } = timeObj.local
 
     return {
       key,
@@ -136,8 +137,8 @@ export class DW {
       domainKey,
       domainInfo: this.config.sites[domainKey],
       timeObj,
-      status: DW.statusText(start, end),
-      canDeploy: DW.canDeploy(start, end),
+      status: DW.statusText(timeObj.local),
+      canDeploy: DW.canDeploy(timeObj.local),
     }
   }
 
@@ -159,27 +160,36 @@ export class DW {
 
     const startTime = new Timezones(start, timezone)
     const endTime = new Timezones(end, timezone)
+    const days = toWeekdays(time?.days)
 
     return {
       original: {
         start: startTime.toOriginalTime(),
         end: endTime.toOriginalTime(),
         timezone: endTime.getOriginalTimezone(),
+        days,
       },
       local: {
         start: startTime.toLocalTime(),
         end: endTime.toLocalTime(),
         timezone: endTime.getLocalTimezone(),
+        // Shifted by the *start*, because that is the moment a day names.
+        days: shiftDays(days, startTime.dayShift()),
       },
     }
   }
 
-  static canDeploy(startTime: string, endTime: string): boolean {
-    return Timezones.isDeploymentWindow(startTime, endTime)
+  /**
+   * These take the window rather than two loose strings on purpose. Days were
+   * added later, and a signature of `(start, end)` is one every existing call
+   * site would have gone on satisfying while quietly ignoring them.
+   */
+  static canDeploy(window: WindowSpec): boolean {
+    return Timezones.isOpen(window)
   }
 
-  static statusText(startTime: string, endTime: string): string {
-    return DW.canDeploy(startTime, endTime)
+  static statusText(window: WindowSpec): string {
+    return DW.canDeploy(window)
       ? Methods.i18n('l10nDeploymentOpen')
       : Methods.i18n('l10nDeploymentClosed')
   }
@@ -192,8 +202,8 @@ export class DW {
    * around. Empty when the times cannot be read, so every caller can render it
    * unconditionally.
    */
-  static countdownText(startTime: string, endTime: string): string {
-    const countdown = Timezones.countdown(startTime, endTime)
+  static countdownText(window: WindowSpec): string {
+    const countdown = Timezones.countdownFor(window)
     if (!countdown) {
       return ''
     }
@@ -204,10 +214,11 @@ export class DW {
   }
 
   /**
-   * Whole minutes as "2h 10m".
+   * Whole minutes as "2h 10m", or "3d 4h" once a window is days away.
    *
-   * A window never sits more than a day away, so hours are the largest unit
-   * needed. Anything under a minute is worded rather than shown as "0m", which
+   * Two units at most. "3d 4h 12m" is a worse answer than "3d 4h" for anything
+   * anyone plans around, and the minutes on the end of a three day wait are
+   * noise. Anything under a minute is worded rather than shown as "0m", which
    * reads as though it has already happened.
    */
   private static duration(minutes: number): string {
@@ -215,9 +226,18 @@ export class DW {
       return Methods.i18n('l10nUnderAMinute')
     }
 
-    const hours = Math.floor(minutes / MINUTES_PER_HOUR)
+    const days = Math.floor(minutes / MINUTES_PER_DAY)
+    const hours = Math.floor((minutes % MINUTES_PER_DAY) / MINUTES_PER_HOUR)
     const rest = minutes % MINUTES_PER_HOUR
     const parts: string[] = []
+
+    if (days > 0) {
+      parts.push(`${days}${Methods.i18n('l10nDaysShort')}`)
+      if (hours > 0) {
+        parts.push(`${hours}${Methods.i18n('l10nHoursShort')}`)
+      }
+      return parts.join(' ')
+    }
 
     if (hours > 0) {
       parts.push(`${hours}${Methods.i18n('l10nHoursShort')}`)

--- a/src/app/components/Notice.ts
+++ b/src/app/components/Notice.ts
@@ -3,6 +3,7 @@ import { GLYPHS, GLYPH_VIEWBOX, glyphFor } from '../glyphs'
 import type { IconState } from '../icons'
 import { isCssSpacing } from '../config/css'
 import { Methods } from './Methods'
+import { daysLabel } from './dayLabels'
 import { renderNotes as renderMarkdown } from './Markdown'
 import { TextFormatter } from './TextFormatter'
 import { Timezones } from './Timezones'
@@ -94,8 +95,7 @@ export class Notice {
     if (this.deployment.notesOnly) {
       return 'notes'
     }
-    const { start, end } = this.deployment.timeObj.local
-    return DW.canDeploy(start, end) ? 'open' : 'closed'
+    return DW.canDeploy(this.deployment.timeObj.local) ? 'open' : 'closed'
   }
 
   /** Build the notice element. Does not touch the document. */
@@ -322,13 +322,13 @@ export class Notice {
 
   /** "Closes in 2h 10m", for the head. */
   private countdownText(): string {
-    const { start, end } = this.deployment.timeObj.local
-    return DW.countdownText(start, end)
+    return DW.countdownText(this.deployment.timeObj.local)
   }
 
   private statusPill(): string {
-    const { start, end } = this.deployment.timeObj.local
-    const status = TextFormatter.stripTags(DW.statusText(start, end))
+    const status = TextFormatter.stripTags(
+      DW.statusText(this.deployment.timeObj.local),
+    )
     // role="status" is a polite live region: the window opening or closing is
     // the one thing here worth interrupting for, and it happens while the page
     // is just sitting there with nobody looking at this corner of it.
@@ -366,9 +366,11 @@ export class Notice {
     window: ResolvedDeployment['timeObj']['original'],
   ): string {
     const t = TextFormatter.stripTags
+    const days = daysLabel(window.days)
     return `<div class="row">
       <dt>${label}</dt>
       <dd>
+        ${days ? `<span class="days">${t(days)}</span>` : ''}
         <span class="time">${t(window.start)} &ndash; ${t(window.end)}</span>
         <span class="zone">${t(window.timezone)}</span>
       </dd>
@@ -395,8 +397,9 @@ export class Notice {
 
   /** Push the open/closed icon to the service worker, but only on change. */
   updateIcon(): void {
-    const { start, end } = this.deployment.timeObj.local
-    const icon = DW.canDeploy(start, end) ? ICONS.open : ICONS.closed
+    const icon = DW.canDeploy(this.deployment.timeObj.local)
+      ? ICONS.open
+      : ICONS.closed
     if (icon !== this.lastIcon) {
       this.lastIcon = icon
       Methods.updateIcon(icon)
@@ -542,15 +545,13 @@ export class Notice {
 
   /** One tick: refresh the clock, the status text and the notice's tone. */
   realTime(): void {
-    const { start, end } = this.deployment.timeObj.local
-
     if (this.clock) {
       this.clock.textContent = Timezones.getCurrentTime()
     }
     // Only written when it actually changed. It is a live region and this runs
     // every second, so re-assigning the same sentence would have a screen
     // reader announce "deployment window open" once a second, all day.
-    const status = DW.statusText(start, end)
+    const status = DW.statusText(this.deployment.timeObj.local)
     if (this.statusText && this.statusText.textContent !== status) {
       this.statusText.textContent = status
     }

--- a/src/app/components/Timezones.ts
+++ b/src/app/components/Timezones.ts
@@ -7,11 +7,26 @@ dayjs.extend(utc)
 dayjs.extend(customParseFormat)
 dayjs.extend(timezone)
 
+import {
+  WEEKDAYS,
+  type Weekday,
+  isEveryDay,
+  previousDay,
+  weekdayOf,
+} from './weekdays'
+
 const HH_MM_FORMAT = 'HH:mm'
 const HH_MM_SS_FORMAT = 'HH:mm:ss'
 
 const TIME_SEPARATOR = ':'
 const MINUTES_PER_DAY = 24 * 60
+
+const WEEK_ORDER = WEEKDAYS
+const DAYS_IN_WEEK = WEEKDAYS.length
+const MAX_DAY_INDEX = DAYS_IN_WEEK - 1
+const WEEK_INDEX: Record<Weekday, number> = Object.fromEntries(
+  WEEKDAYS.map((day, index) => [day, index]),
+) as Record<Weekday, number>
 
 /** Any date works for formatting a bare time; this one is just a fixed anchor. */
 const ANCHOR_DATE = '2000-01-01'
@@ -22,6 +37,20 @@ export interface WindowCountdown {
   open: boolean
   /** Whole minutes until it closes, or until it next opens. */
   minutes: number
+}
+
+/**
+ * A window as something to ask questions of: when it opens, when it closes and
+ * which days it opens on.
+ *
+ * Passed as one object rather than as loose strings so the days cannot be
+ * quietly dropped at a call site that predates them.
+ */
+export interface WindowSpec {
+  start: string
+  end: string
+  /** Days the window opens on. Empty means every day. */
+  days?: readonly Weekday[]
 }
 
 export interface CurrentDate {
@@ -120,6 +149,32 @@ export class Timezones {
     return this.toLocalTime(this.getLocalTimezone())
   }
 
+  /**
+   * How many calendar days converting this time into the viewer's zone moves
+   * it: -1, 0 or 1.
+   *
+   * Only the clock face survives {@link toLocalTime}, so a Tokyo morning shown
+   * in Los Angeles keeps its hours and silently loses the fact that it is the
+   * previous afternoon there. The days a window opens on have to move by the
+   * same amount, or a Monday window would be advertised as opening on the
+   * viewer's Monday when their calendar says Sunday.
+   */
+  dayShift(): number {
+    const source = dayjs.tz(this.getFormattedTime(), this.getOriginalTimezone())
+    const local = source.tz(this.getLocalTimezone())
+    const difference = local.day() - source.day()
+
+    // Across the Saturday/Sunday boundary the raw difference comes out as the
+    // long way round the week.
+    if (difference === MAX_DAY_INDEX) {
+      return -1
+    }
+    if (difference === -MAX_DAY_INDEX) {
+      return 1
+    }
+    return difference
+  }
+
   static findLocalTimezone(): string {
     return dayjs.tz.guess()
   }
@@ -215,6 +270,89 @@ export class Timezones {
       open,
       minutes: (target - now + MINUTES_PER_DAY) % MINUTES_PER_DAY,
     }
+  }
+
+  /**
+   * Is the window open, taking its days into account?
+   *
+   * The day a window names is the day it *opens*. It has to be: a 23:00-02:00
+   * window on Monday is one window - Monday night - not two hours of Monday
+   * and two hours of Tuesday. So for a window that wraps past midnight, the
+   * hours after midnight belong to the day before.
+   */
+  static isOpen(spec: WindowSpec, at: Date = new Date()): boolean {
+    const start = toMinutesOfDay(spec.start)
+    const end = toMinutesOfDay(spec.end)
+    if (start === null || end === null) {
+      return false
+    }
+
+    const now = at.getHours() * 60 + at.getMinutes()
+    const inHours =
+      start <= end ? now >= start && now <= end : now >= start || now <= end
+    if (!inHours) {
+      return false
+    }
+
+    const days = spec.days ?? []
+    if (isEveryDay(days)) {
+      return true
+    }
+
+    const today = weekdayOf(at)
+    // Past midnight on a wrapping window: the window that is open now is the
+    // one that opened yesterday.
+    const openedOn = start <= end || now >= start ? today : previousDay(today)
+    return days.includes(openedOn)
+  }
+
+  /**
+   * How long until the window changes state, in whole minutes.
+   *
+   * Unlike the time-only {@link countdown} this looks forward through the week,
+   * because with days a window can be several days from opening. Closing is
+   * always within a day of now - the window is open, so its end is the next
+   * boundary either way.
+   */
+  static countdownFor(
+    spec: WindowSpec,
+    at: Date = new Date(),
+  ): WindowCountdown | null {
+    const start = toMinutesOfDay(spec.start)
+    const end = toMinutesOfDay(spec.end)
+    if (start === null || end === null) {
+      return null
+    }
+
+    const now = at.getHours() * 60 + at.getMinutes()
+
+    if (Timezones.isOpen(spec, at)) {
+      return { open: true, minutes: (end - now + MINUTES_PER_DAY) % MINUTES_PER_DAY }
+    }
+
+    const days = spec.days ?? []
+    if (isEveryDay(days)) {
+      return { open: false, minutes: (start - now + MINUTES_PER_DAY) % MINUTES_PER_DAY }
+    }
+
+    // Walk forward to the next day the window opens on. Eight steps rather
+    // than seven so that "a week today" is reachable from a day whose opening
+    // has already been and gone.
+    const today = weekdayOf(at)
+    const todayIndex = WEEK_INDEX[today]
+    for (let offset = 0; offset <= DAYS_IN_WEEK; offset += 1) {
+      const day = WEEK_ORDER[(todayIndex + offset) % DAYS_IN_WEEK]
+      if (!days.includes(day)) {
+        continue
+      }
+      // Today only counts if its opening is still ahead of us.
+      if (offset === 0 && now >= start) {
+        continue
+      }
+      return { open: false, minutes: offset * MINUTES_PER_DAY + start - now }
+    }
+
+    return null
   }
 
   /** Minutes since local midnight, right now. */

--- a/src/app/components/dayLabels.ts
+++ b/src/app/components/dayLabels.ts
@@ -1,0 +1,18 @@
+import { Methods } from './Methods'
+import {
+  type Weekday,
+  dayMessageKey,
+  formatWeekdays,
+} from './weekdays'
+
+/**
+ * A window's days as text, in the viewer's language.
+ *
+ * The formatting lives in weekdays.ts, which knows nothing about the extension
+ * APIs; this is the thin part that hands it the labels. Empty when the window
+ * opens every day - there is no constraint to report, and reporting one anyway
+ * is how a notice ends up saying more than it means.
+ */
+export function daysLabel(days: readonly Weekday[]): string {
+  return formatWeekdays(days, (day) => Methods.i18n(dayMessageKey(day)))
+}

--- a/src/app/components/weekdays.ts
+++ b/src/app/components/weekdays.ts
@@ -1,0 +1,167 @@
+/**
+ * Days of the week, as the config writes them.
+ *
+ * Stored as short names rather than numbers because the config is hand-edited
+ * and passed between people: `["mon", "tue", "wed", "thu"]` says what it means
+ * and `[1, 2, 3, 4]` needs a lookup and an argument about whether weeks start
+ * on Sunday.
+ *
+ * The order here is JavaScript's - `Date.getDay()` returns 0 for Sunday - and
+ * is used for indexing, never for display. What the interface shows starts on
+ * Monday, which is what a working week means to the people configuring one.
+ */
+
+export const WEEKDAYS = [
+  'sun',
+  'mon',
+  'tue',
+  'wed',
+  'thu',
+  'fri',
+  'sat',
+] as const
+
+export type Weekday = (typeof WEEKDAYS)[number]
+
+/** Monday first, for anything a person reads. */
+export const WEEK_DISPLAY_ORDER: readonly Weekday[] = [
+  'mon',
+  'tue',
+  'wed',
+  'thu',
+  'fri',
+  'sat',
+  'sun',
+]
+
+const DAYS_PER_WEEK = WEEKDAYS.length
+
+export function isWeekday(value: unknown): value is Weekday {
+  return (
+    typeof value === 'string' && (WEEKDAYS as readonly string[]).includes(value)
+  )
+}
+
+/** The weekday `date` falls on. */
+export function weekdayOf(date: Date): Weekday {
+  return WEEKDAYS[date.getDay()]
+}
+
+/** `days` shifted by whole days, wrapping around the week. */
+export function shiftDays(days: readonly Weekday[], by: number): Weekday[] {
+  if (by === 0) {
+    return [...days]
+  }
+  return days.map((day) => {
+    const index = WEEKDAYS.indexOf(day)
+    return WEEKDAYS[(index + by + DAYS_PER_WEEK * 7) % DAYS_PER_WEEK]
+  })
+}
+
+/** The day before `day`. */
+export function previousDay(day: Weekday): Weekday {
+  return WEEKDAYS[(WEEKDAYS.indexOf(day) + DAYS_PER_WEEK - 1) % DAYS_PER_WEEK]
+}
+
+/**
+ * Read a stored `days` value, dropping anything unrecognised.
+ *
+ * An empty result means every day. That is what an absent key has always meant
+ * and it is what an empty list most likely means too - "no days at all" is a
+ * deployment window that can never open, which nobody sets on purpose.
+ */
+export function toWeekdays(value: unknown): Weekday[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+  const seen = new Set<Weekday>()
+  for (const entry of value) {
+    if (isWeekday(entry)) {
+      seen.add(entry)
+    }
+  }
+  return WEEKDAYS.filter((day) => seen.has(day))
+}
+
+/** Does this set of days constrain anything? */
+export function isEveryDay(days: readonly Weekday[]): boolean {
+  return days.length === 0 || days.length === DAYS_PER_WEEK
+}
+
+/**
+ * The message key holding the short label for a day.
+ *
+ * Spelled out rather than built from the day name. check-locales.js reads the
+ * source for the keys it can see, so a computed one is invisible to it - and a
+ * message key nothing can verify is one that breaks quietly when it is
+ * renamed. It caught exactly that when these were assembled from the day name.
+ */
+const DAY_MESSAGE_KEYS: Record<Weekday, string> = {
+  mon: 'l10nDayMon',
+  tue: 'l10nDayTue',
+  wed: 'l10nDayWed',
+  thu: 'l10nDayThu',
+  fri: 'l10nDayFri',
+  sat: 'l10nDaySat',
+  sun: 'l10nDaySun',
+}
+
+export function dayMessageKey(day: Weekday): string {
+  return DAY_MESSAGE_KEYS[day]
+}
+
+/**
+ * Split a set of days into consecutive runs, in the order a person reads them.
+ *
+ * "Mon, Tue, Wed, Thu" is four facts to hold; "Mon-Thu" is one. Runs are found
+ * against the display order rather than the storage order, so a Saturday and
+ * Sunday pair reads as the weekend it is rather than being split across the
+ * ends of the list.
+ */
+export function groupWeekdays(days: readonly Weekday[]): Weekday[][] {
+  const present = WEEK_DISPLAY_ORDER.filter((day) => days.includes(day))
+  const runs: Weekday[][] = []
+
+  for (const day of present) {
+    const run = runs[runs.length - 1]
+    const previous = run?.[run.length - 1]
+    if (
+      run &&
+      previous &&
+      WEEK_DISPLAY_ORDER.indexOf(day) === WEEK_DISPLAY_ORDER.indexOf(previous) + 1
+    ) {
+      run.push(day)
+    } else {
+      runs.push([day])
+    }
+  }
+
+  return runs
+}
+
+/**
+ * A set of days as text, e.g. "Mon-Thu" or "Mon, Wed, Fri".
+ *
+ * Takes the labels rather than reaching for them, so the shape of this is
+ * testable without a message catalogue and the module stays free of the
+ * extension APIs - it is on the content script's path.
+ *
+ * A run of two is listed rather than ranged: "Sat, Sun" is no longer than
+ * "Sat-Sun" and does not ask the reader to expand anything.
+ */
+export function formatWeekdays(
+  days: readonly Weekday[],
+  label: (day: Weekday) => string,
+): string {
+  if (isEveryDay(days)) {
+    return ''
+  }
+
+  return groupWeekdays(days)
+    .map((run) =>
+      run.length > 2
+        ? `${label(run[0])}\u2013${label(run[run.length - 1])}`
+        : run.map(label).join(', '),
+    )
+    .join(', ')
+}

--- a/src/app/config/schema.ts
+++ b/src/app/config/schema.ts
@@ -16,10 +16,13 @@ import type { DeploymentWindowsConfig } from './types'
  * "must ..." message - so they stay familiar and are safe to show verbatim.
  */
 
+import { WEEKDAYS, isWeekday } from '../components/weekdays'
 import { isCssSpacing } from './css'
 
 const TIME_PATTERN = /^([01]\d|2[0-3]):[0-5]\d$/
 const INSERT_POSITIONS = ['before', 'after'] as const
+
+const TIME_KNOWN_KEYS = new Set(['start', 'end', 'timezone', 'days'])
 
 const DEPLOYMENT_KNOWN_KEYS = new Set([
   'name',
@@ -221,11 +224,46 @@ function validateTime(value: unknown, path: string, errors: Errors): void {
     )
   }
 
+  if ('days' in value) {
+    validateDays(value.days, join(path, 'days'), errors)
+  }
+
   for (const extra of Object.keys(value)) {
-    if (extra !== 'start' && extra !== 'end' && extra !== 'timezone') {
+    if (!TIME_KNOWN_KEYS.has(extra)) {
       errors.add(path, `must NOT have additional properties ('${extra}')`)
     }
   }
+}
+
+/**
+ * Which days a window opens on.
+ *
+ * Rejected rather than quietly filtered: a config is something people read and
+ * copy between machines, so `"monday"` where `"mon"` was meant is worth naming
+ * where it was written. At runtime the same value is filtered instead, because
+ * by then there is nobody to tell.
+ */
+function validateDays(value: unknown, path: string, errors: Errors): void {
+  if (!Array.isArray(value)) {
+    errors.type(path, 'array')
+    return
+  }
+
+  const seen = new Set<string>()
+  value.forEach((entry, index) => {
+    const at = `${path}/${String(index)}`
+    if (!isWeekday(entry)) {
+      errors.add(
+        at,
+        `must be one of ${WEEKDAYS.map((day) => `"${day}"`).join(', ')}`,
+      )
+      return
+    }
+    if (seen.has(entry)) {
+      errors.add(at, `must not repeat a day ("${entry}")`)
+    }
+    seen.add(entry)
+  })
 }
 
 function validateDeployments(value: unknown, path: string, errors: Errors): void {

--- a/src/app/config/types.ts
+++ b/src/app/config/types.ts
@@ -3,6 +3,8 @@
  * deployment that the notice and popup render from.
  */
 
+import type { Weekday } from '../components/weekdays'
+
 export type InsertPosition = 'before' | 'after'
 
 export interface InsertLocation {
@@ -38,6 +40,14 @@ export interface DeploymentTime {
   end: string
   /** IANA timezone, e.g. Europe/London */
   timezone: string
+  /**
+   * Days the window opens on, e.g. `["mon", "tue", "wed", "thu"]`.
+   *
+   * Absent means every day, which is what every config written before this
+   * existed means. A day names when the window *opens*: a Monday 23:00-02:00
+   * window runs into Tuesday morning and is still Monday's window.
+   */
+  days?: Weekday[]
 }
 
 /**
@@ -67,6 +77,13 @@ export interface ResolvedTimeWindow {
   start: string
   end: string
   timezone: string
+  /**
+   * Days this window opens on, in this window's own terms. Empty means every
+   * day. On the local window these are shifted with the times, so a Monday in
+   * Tokyo can read as a Sunday in Los Angeles - which is what the viewer's
+   * calendar actually says.
+   */
+  days: Weekday[]
 }
 
 export interface ResolvedTimes {

--- a/src/documents/HowToUse.md
+++ b/src/documents/HowToUse.md
@@ -129,6 +129,22 @@ The GitHub and Jira entries a fresh install starts with are a demonstration
 rather than a saved config, so connecting a shared config replaces them. Add
 them back from the Sites section if you need them.
 
+### Which days it opens on
+
+By default a window opens every day. Untick the days it should not, and the card
+and the notice will say so — "Mon–Fri", or "Mon, Wed, Fri".
+
+**A day is when the window opens.** That matters for a window that runs past
+midnight: `23:00`–`02:00` on Monday is Monday night, and it stays open into
+Tuesday morning. It is one window, and it belongs to the day it started.
+
+If the window is written in someone else's timezone, the days move with the
+hours. A Monday morning in Tokyo is Sunday afternoon in Los Angeles, so that is
+what the converted row says — the notice tells you what your own calendar says,
+not what the person who wrote the config was looking at.
+
+When the next window is days away, the countdown says so: "Opens in 2d 4h".
+
 ---
 
 ## Editing the JSON directly
@@ -170,7 +186,8 @@ The stored config has three parts: `domains`, `sites` and `deployments`.
             "time": {
                 "start": "23:00",
                 "end": "02:00",
-                "timezone": "Europe/Paris"
+                "timezone": "Europe/Paris",
+                "days": ["mon", "tue", "wed", "thu"]
             },
             "notes": "Deploys need **two** approvals."
         }
@@ -212,3 +229,4 @@ time|object[time_data]|The deployment window
 time.time_data.start|time[24]|24 hour time the window opens, e.g. `09:00`
 time.time_data.end|time[24]|24 hour time the window closes; may be earlier than the start to run past midnight
 time.time_data.timezone|string|An [IANA timezone](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) such as `Europe/London`
+time.time_data.days|array[day]|Days the window opens on, e.g. `["mon","tue","wed","thu","fri"]`. Leave it out for every day

--- a/src/styles/forms.css
+++ b/src/styles/forms.css
@@ -355,3 +355,65 @@
   align-self: start;
   margin-top: var(--dw-field-label-offset);
 }
+
+/* ------------------------------------------------------------------ */
+/* days                                                                */
+/* ------------------------------------------------------------------ */
+
+/* Which days a window opens on, shown beside its hours. Reads ahead of them
+   because it is the coarser fact: there is no point reading 09:00 before
+   knowing whether today is one of the days at all. */
+.dw-days {
+  font-size: 0.82rem;
+  font-weight: 640;
+  color: var(--dw-accent-soft-text);
+  background: var(--dw-accent-soft);
+  padding: 1px 7px;
+  border-radius: var(--dw-radius-sm);
+  white-space: nowrap;
+}
+
+/* A row of days to tick, rather than seven stacked checkboxes. The week is
+   something people read across, and a set of toggles you can run a finger
+   along says "pick some of these" better than a column of labels does. */
+.dw-daypicker {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.dw-day {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 46px;
+  padding: 6px 10px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--dw-text-muted);
+  background: var(--dw-surface);
+  border: 1px solid var(--dw-border-strong);
+  border-radius: var(--dw-radius-sm);
+  cursor: pointer;
+  user-select: none;
+  transition:
+    background var(--dw-transition),
+    color var(--dw-transition),
+    border-color var(--dw-transition);
+}
+
+.dw-day:hover {
+  border-color: var(--dw-accent);
+}
+
+.dw-day-on {
+  color: var(--dw-accent-text);
+  background: var(--dw-accent);
+  border-color: var(--dw-accent);
+}
+
+/* The input is visually hidden, so the ring has to be put on the label. */
+.dw-day:has(:focus-visible) {
+  outline: 2px solid var(--dw-focus);
+  outline-offset: 2px;
+}

--- a/src/styles/notice.css
+++ b/src/styles/notice.css
@@ -328,6 +328,15 @@
 /* the times                                                           */
 /* ------------------------------------------------------------------ */
 
+/* Which days the window opens on, when it is not all of them. Reads ahead of
+   the hours because it is the coarser fact: there is no point reading 09:00
+   before knowing whether today is one of the days at all. */
+.days {
+  font-weight: 640;
+  color: var(--dw-tone);
+  white-space: nowrap;
+}
+
 .rows {
   display: flex;
   flex-wrap: wrap;

--- a/src/ui/components/Popup.tsx
+++ b/src/ui/components/Popup.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 
 import { DW } from '../../app/components/DW'
 import { Methods } from '../../app/components/Methods'
+import { daysLabel } from '../../app/components/dayLabels'
 import { TextFormatter } from '../../app/components/TextFormatter'
 import { Config } from '../../app/config/Config'
 import type {
@@ -129,8 +130,7 @@ function toneFor(deployment: ResolvedDeployment): StatusTone {
   if (deployment.notesOnly) {
     return 'notes'
   }
-  const { start, end } = deployment.timeObj.local
-  return DW.canDeploy(start, end) ? 'open' : 'closed'
+  return DW.canDeploy(deployment.timeObj.local) ? 'open' : 'closed'
 }
 
 /** The active tab's favicon, from Chrome's own cache, or its initial. */
@@ -219,6 +219,8 @@ function Window({ deployment }: { deployment: ResolvedDeployment }) {
   const { original, local } = deployment.timeObj
   // The converted window is only worth the space when it actually differs.
   const showLocal = original.timezone !== local.timezone
+  const originalDays = daysLabel(original.days)
+  const localDays = daysLabel(local.days)
 
   return (
     <dl className="dw-popup-rows">
@@ -228,6 +230,7 @@ function Window({ deployment }: { deployment: ResolvedDeployment }) {
           {Methods.i18n('l10nDeploymentWindow')}
         </dt>
         <dd>
+          {originalDays && <span className="dw-days">{originalDays}</span>}
           <span className="dw-mono">
             {original.start} &ndash; {original.end}
           </span>
@@ -238,6 +241,7 @@ function Window({ deployment }: { deployment: ResolvedDeployment }) {
         <div className="dw-popup-row dw-popup-row-subtle">
           <dt>{Methods.i18n('l10nYourTimezone')}</dt>
           <dd>
+            {localDays && <span className="dw-days">{localDays}</span>}
             <span className="dw-mono">
               {local.start} &ndash; {local.end}
             </span>
@@ -291,10 +295,7 @@ function Deployment({
           {TextFormatter.toPlainText(deployment.name)}
         </h1>
         {!deployment.notesOnly && (
-          <Countdown
-            start={deployment.timeObj.local.start}
-            end={deployment.timeObj.local.end}
-          />
+          <Countdown window={deployment.timeObj.local} />
         )}
       </header>
 

--- a/src/ui/components/common/Countdown.tsx
+++ b/src/ui/components/common/Countdown.tsx
@@ -1,4 +1,5 @@
 import { DW } from '../../../app/components/DW'
+import type { ResolvedTimeWindow } from '../../../app/config/types'
 
 /**
  * How much longer the window stays as it is.
@@ -10,13 +11,13 @@ import { DW } from '../../../app/components/DW'
  * It recomputes rather than taking a snapshot, so it needs its parent to be
  * re-rendering - see useNow.
  */
-export function Countdown({ start, end }: { start: string; end: string }) {
-  const text = DW.countdownText(start, end)
+export function Countdown({ window }: { window: ResolvedTimeWindow }) {
+  const text = DW.countdownText(window)
   if (!text) {
     return null
   }
 
-  const tone = DW.canDeploy(start, end) ? 'open' : 'closed'
+  const tone = DW.canDeploy(window) ? 'open' : 'closed'
   return <span className={`dw-countdown dw-countdown-${tone}`}>{text}</span>
 }
 

--- a/src/ui/components/dashboard/DeploymentCard.tsx
+++ b/src/ui/components/dashboard/DeploymentCard.tsx
@@ -1,4 +1,5 @@
 import { DW } from '../../../app/components/DW'
+import { daysLabel } from '../../../app/components/dayLabels'
 import { Methods } from '../../../app/components/Methods'
 import { TextFormatter } from '../../../app/components/TextFormatter'
 import type { DeploymentConfig } from '../../../app/config/types'
@@ -33,7 +34,7 @@ export function statusFor(deployment: DeploymentConfig): StatusTone {
     return 'unset'
   }
   const { local } = DW.buildTimes(deployment)
-  return DW.canDeploy(local.start, local.end) ? 'open' : 'closed'
+  return DW.canDeploy(local) ? 'open' : 'closed'
 }
 
 /**
@@ -103,7 +104,7 @@ export function DeploymentCard({
         <div className="dw-card-status">
           <StatusPill tone={tone} />
           {times && tone !== 'notes' && tone !== 'unset' && (
-            <Countdown start={times.local.start} end={times.local.end} />
+            <Countdown window={times.local} />
           )}
         </div>
       </header>
@@ -120,6 +121,11 @@ export function DeploymentCard({
               </span>
             </dt>
             <dd>
+              {daysLabel(times.original.days) && (
+                <span className="dw-days">
+                  {daysLabel(times.original.days)}
+                </span>
+              )}
               <span className="dw-mono">
                 {times.original.start} &ndash; {times.original.end}
               </span>
@@ -130,6 +136,9 @@ export function DeploymentCard({
             <div className="dw-card-row dw-card-row-subtle">
               <dt>{Methods.i18n('l10nYourTimezone')}</dt>
               <dd>
+                {daysLabel(times.local.days) && (
+                  <span className="dw-days">{daysLabel(times.local.days)}</span>
+                )}
                 <span className="dw-mono">
                   {times.local.start} &ndash; {times.local.end}
                 </span>

--- a/src/ui/components/dashboard/DeploymentForm.tsx
+++ b/src/ui/components/dashboard/DeploymentForm.tsx
@@ -2,6 +2,10 @@ import { useId, useState } from 'react'
 
 import { Methods } from '../../../app/components/Methods'
 import { Timezones } from '../../../app/components/Timezones'
+import {
+  WEEK_DISPLAY_ORDER,
+  dayMessageKey,
+} from '../../../app/components/weekdays'
 import type { DeploymentConfig } from '../../../app/config/types'
 import Field from '../common/Field'
 import Modal from '../common/Modal'
@@ -231,6 +235,45 @@ export function DeploymentForm({
                 <option key={zone} value={zone} />
               ))}
             </datalist>
+
+            <Field
+              label={Methods.i18n('l10nDays')}
+              hint={Methods.i18n('l10nDaysHint')}
+              error={shown('days')}
+            >
+              {({ describedBy }) => (
+                <div
+                  className="dw-daypicker"
+                  role="group"
+                  aria-describedby={describedBy}
+                  aria-label={Methods.i18n('l10nDays')}
+                >
+                  {WEEK_DISPLAY_ORDER.map((day) => {
+                    const on = draft.days.includes(day)
+                    return (
+                      <label
+                        key={day}
+                        className={`dw-day${on ? ' dw-day-on' : ''}`}
+                      >
+                        <input
+                          type="checkbox"
+                          className="dw-visually-hidden"
+                          checked={on}
+                          onChange={() =>
+                            update({
+                              days: on
+                                ? draft.days.filter((d) => d !== day)
+                                : [...draft.days, day],
+                            })
+                          }
+                        />
+                        {Methods.i18n(dayMessageKey(day))}
+                      </label>
+                    )
+                  })}
+                </div>
+              )}
+            </Field>
           </fieldset>
         )}
 

--- a/src/ui/components/dashboard/drafts.ts
+++ b/src/ui/components/dashboard/drafts.ts
@@ -1,5 +1,11 @@
 import { Methods } from '../../../app/components/Methods'
 import { Timezones, isValidTimezone } from '../../../app/components/Timezones'
+import {
+  WEEKDAYS,
+  type Weekday,
+  isEveryDay,
+  toWeekdays,
+} from '../../../app/components/weekdays'
 import { MatchPattern } from '../../../app/matching/MatchPattern'
 import { isCssSpacing } from '../../../app/config/css'
 import type {
@@ -39,6 +45,12 @@ export interface DeploymentDraft {
   start: string
   end: string
   timezone: string
+  /**
+   * Days the window opens on. All seven, which is the default, means the same
+   * as none - the form ticks them all rather than showing an empty row that
+   * reads as a window that never opens.
+   */
+  days: Weekday[]
   /** domain key -> url fragment, one entry per configured site. */
   fragments: Record<string, string>
 }
@@ -71,6 +83,7 @@ export function toDeploymentDraft(
   }
 
   const time = deployment.time
+  const stored = toWeekdays(time?.days)
 
   return {
     key,
@@ -81,6 +94,7 @@ export function toDeploymentDraft(
     start: time?.start ?? '09:00',
     end: time?.end ?? '17:00',
     timezone: time?.timezone ?? Timezones.findLocalTimezone(),
+    days: stored.length > 0 ? stored : [...WEEKDAYS],
     fragments,
   }
 }
@@ -109,6 +123,11 @@ export function fromDeploymentDraft(draft: DeploymentDraft): DeploymentConfig {
       start: draft.start.trim(),
       end: draft.end.trim(),
       timezone: draft.timezone.trim(),
+    }
+    // Left off entirely when the window opens every day, so a config that
+    // never cared about days does not grow a key saying so.
+    if (!isEveryDay(draft.days)) {
+      deployment.time.days = WEEKDAYS.filter((day) => draft.days.includes(day))
     }
   }
 
@@ -149,6 +168,10 @@ export function validateDeploymentDraft(
     }
     if (!isValidTimezone(draft.timezone.trim())) {
       errors.timezone = Methods.i18n('l10nInvalidTimezone')
+    }
+    // A window with no days can never open, which is never what was meant.
+    if (draft.days.length === 0) {
+      errors.days = Methods.i18n('l10nDaysRequired')
     }
   }
 

--- a/tests/devHarness.test.ts
+++ b/tests/devHarness.test.ts
@@ -63,6 +63,7 @@ describe('dev harness', () => {
         start: '09:00',
         end: '17:00',
         timezone: 'Asia/Tokyo',
+        days: [],
       })
       // Tests are pinned to America/New_York, so the local window must differ.
       expect(info?.timeObj.local.timezone).toBe('America/New_York')

--- a/tests/dw.test.ts
+++ b/tests/dw.test.ts
@@ -2,9 +2,15 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { DW } from '../src/app/components/DW'
 import { Timezones } from '../src/app/components/Timezones'
+import type { Weekday } from '../src/app/components/weekdays'
 import { Config, STORAGE_KEYS, defaultConfig } from '../src/app/config/Config'
 import { seedStorage } from './helpers/chromeMock'
 import { testConfig } from './helpers/fixtures'
+
+/** A window to ask about, with no day constraint. */
+function win(start: string, end: string, days: Weekday[] = []) {
+  return { start, end, timezone: 'Europe/London', days }
+}
 
 describe('DW', () => {
   beforeEach(() => {
@@ -121,6 +127,8 @@ describe('DW', () => {
         start: '09:00',
         end: '17:00',
         timezone: 'Europe/London',
+        // No days configured, which means every day.
+        days: [],
       })
       expect(times.local.timezone).toBe(Timezones.findLocalTimezone())
       expect(times.local.start).toMatch(/^\d{2}:\d{2}$/)
@@ -139,21 +147,21 @@ describe('DW', () => {
     it('reports open inside the window', () => {
       vi.useFakeTimers()
       vi.setSystemTime(new Date('2024-06-03T12:00:00'))
-      expect(DW.canDeploy('09:00', '17:00')).toBe(true)
-      expect(DW.statusText('09:00', '17:00')).toBe('Deployment window open')
+      expect(DW.canDeploy(win('09:00', '17:00'))).toBe(true)
+      expect(DW.statusText(win('09:00', '17:00'))).toBe('Deployment window open')
     })
 
     it('reports closed outside the window', () => {
       vi.useFakeTimers()
       vi.setSystemTime(new Date('2024-06-03T20:00:00'))
-      expect(DW.canDeploy('09:00', '17:00')).toBe(false)
-      expect(DW.statusText('09:00', '17:00')).toBe('Deployment window closed')
+      expect(DW.canDeploy(win('09:00', '17:00'))).toBe(false)
+      expect(DW.statusText(win('09:00', '17:00'))).toBe('Deployment window closed')
     })
 
     it('handles a window that wraps past midnight', () => {
       vi.useFakeTimers()
       vi.setSystemTime(new Date('2024-06-03T00:30:00'))
-      expect(DW.canDeploy('23:00', '02:00')).toBe(true)
+      expect(DW.canDeploy(win('23:00', '02:00'))).toBe(true)
     })
   })
 
@@ -161,37 +169,37 @@ describe('DW', () => {
     it('says how long an open window has left', () => {
       vi.useFakeTimers()
       vi.setSystemTime(new Date('2024-06-03T12:50:00'))
-      expect(DW.countdownText('09:00', '17:00')).toBe('Closes in 4h 10m')
+      expect(DW.countdownText(win('09:00', '17:00'))).toBe('Closes in 4h 10m')
     })
 
     it('drops the minutes when there are none', () => {
       vi.useFakeTimers()
       vi.setSystemTime(new Date('2024-06-03T12:00:00'))
-      expect(DW.countdownText('09:00', '17:00')).toBe('Closes in 5h')
+      expect(DW.countdownText(win('09:00', '17:00'))).toBe('Closes in 5h')
     })
 
     it('drops the hours when there are none', () => {
       vi.useFakeTimers()
       vi.setSystemTime(new Date('2024-06-03T16:45:00'))
-      expect(DW.countdownText('09:00', '17:00')).toBe('Closes in 15m')
+      expect(DW.countdownText(win('09:00', '17:00'))).toBe('Closes in 15m')
     })
 
     it('says how long until a closed window opens', () => {
       vi.useFakeTimers()
       vi.setSystemTime(new Date('2024-06-03T07:30:00'))
-      expect(DW.countdownText('09:00', '17:00')).toBe('Opens in 1h 30m')
+      expect(DW.countdownText(win('09:00', '17:00'))).toBe('Opens in 1h 30m')
     })
 
     it('words the last minute rather than showing 0m', () => {
       vi.useFakeTimers()
       vi.setSystemTime(new Date('2024-06-03T17:00:30'))
-      expect(DW.countdownText('09:00', '17:00')).toBe(
+      expect(DW.countdownText(win('09:00', '17:00'))).toBe(
         'Closes in under a minute',
       )
     })
 
     it('says nothing at all when the times cannot be read', () => {
-      expect(DW.countdownText('', '17:00')).toBe('')
+      expect(DW.countdownText(win('', '17:00'))).toBe('')
     })
   })
 
@@ -219,5 +227,92 @@ describe('DW', () => {
       const dw = await DW.create('https://github.com/acme/overnight')
       expect(dw.getDeploymentInfo()?.name).toBe('Overnight project')
     })
+  })
+})
+
+describe('DW with days', () => {
+  const MONDAY = '2024-06-03'
+  const SATURDAY = '2024-06-08'
+
+  function weekdaysOnly() {
+    const config = testConfig()
+    config.deployments.daytime.time = {
+      start: '09:00',
+      end: '17:00',
+      timezone: 'America/New_York',
+      days: ['mon', 'tue', 'wed', 'thu', 'fri'],
+    }
+    return config
+  }
+
+  function resolve(config: ReturnType<typeof testConfig>) {
+    return new DW(config, 'https://github.com/acme/daytime').getDeploymentInfo()!
+  }
+
+  it('carries the days through to the resolved window', () => {
+    vi.setSystemTime(new Date(`${MONDAY}T12:00:00`))
+    const info = resolve(weekdaysOnly())
+
+    expect(info.timeObj.original.days).toEqual([
+      'mon',
+      'tue',
+      'wed',
+      'thu',
+      'fri',
+    ])
+  })
+
+  it('is open inside the hours on a working day', () => {
+    vi.setSystemTime(new Date(`${MONDAY}T12:00:00`))
+    expect(resolve(weekdaysOnly()).canDeploy).toBe(true)
+  })
+
+  it('is shut at the same hour on a Saturday', () => {
+    vi.setSystemTime(new Date(`${SATURDAY}T12:00:00`))
+    const info = resolve(weekdaysOnly())
+
+    expect(info.canDeploy).toBe(false)
+    expect(info.status).toBe('Deployment window closed')
+  })
+
+  it('counts across the weekend rather than to tomorrow', () => {
+    vi.setSystemTime(new Date(`${SATURDAY}T12:00:00`))
+    // Saturday noon to Monday 09:00 is a day and 21 hours. Saying "opens in
+    // 21h" would be a lie the old countdown had no way of avoiding.
+    expect(DW.countdownText(resolve(weekdaysOnly()).timeObj.local)).toBe(
+      'Opens in 1d 21h',
+    )
+  })
+
+  it('drops the hours from a whole number of days', () => {
+    vi.setSystemTime(new Date(`${SATURDAY}T09:00:00`))
+    expect(DW.countdownText(resolve(weekdaysOnly()).timeObj.local)).toBe(
+      'Opens in 2d',
+    )
+  })
+
+  it('shifts the days with the hours across a timezone', () => {
+    // A Monday morning in Tokyo is Sunday afternoon in New York, and the days
+    // have to move with the clock or the notice advertises the wrong one.
+    vi.setSystemTime(new Date(`${MONDAY}T12:00:00`))
+    const config = testConfig()
+    config.deployments.daytime.time = {
+      start: '09:00',
+      end: '17:00',
+      timezone: 'Asia/Tokyo',
+      days: ['mon'],
+    }
+    const info = resolve(config)
+
+    expect(info.timeObj.original.days).toEqual(['mon'])
+    expect(info.timeObj.local.days).toEqual(['sun'])
+  })
+
+  it('says nothing about days when the window opens every day', () => {
+    vi.setSystemTime(new Date(`${SATURDAY}T12:00:00`))
+    const info = resolve(testConfig())
+
+    expect(info.timeObj.original.days).toEqual([])
+    expect(info.canDeploy).toBe(true)
   })
 })

--- a/tests/forms.test.tsx
+++ b/tests/forms.test.tsx
@@ -392,3 +392,119 @@ describe('SiteForm', () => {
     expect(screen.getByLabelText(/^Site key/)).toHaveValue('my-site')
   })
 })
+
+describe('DeploymentForm days', () => {
+  function dayToggle(label: string): HTMLInputElement {
+    const box = screen
+      .getAllByRole('checkbox')
+      .find((input) => input.closest('label')?.textContent?.trim() === label)
+    if (!box) {
+      throw new Error(`no day toggle for ${label}`)
+    }
+    return box as HTMLInputElement
+  }
+
+  it('starts with every day on', () => {
+    // A new window opens every day until told otherwise, and an empty row of
+    // days would read as one that never opens.
+    renderDeploymentForm()
+
+    for (const day of ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']) {
+      expect(dayToggle(day).checked).toBe(true)
+    }
+  })
+
+  it('shows the week starting on Monday', () => {
+    renderDeploymentForm()
+    const labels = screen
+      .getAllByRole('checkbox')
+      .map((input) => input.closest('label')?.textContent?.trim())
+      .filter((text) => text && text.length === 3)
+
+    expect(labels).toEqual(['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'])
+  })
+
+  it('reads the days off an existing entry', () => {
+    const config = testConfig()
+    config.deployments.daytime.time = {
+      start: '09:00',
+      end: '17:00',
+      timezone: 'Europe/London',
+      days: ['mon', 'tue'],
+    }
+    renderDeploymentForm({
+      originalKey: 'daytime',
+      initial: toDeploymentDraft('daytime', config.deployments.daytime, DOMAINS),
+    })
+
+    expect(dayToggle('Mon').checked).toBe(true)
+    expect(dayToggle('Wed').checked).toBe(false)
+  })
+
+  it('writes the days back when some are off', async () => {
+    const user = userEvent.setup()
+    const props = renderDeploymentForm({
+      initial: {
+        ...emptyDeploymentDraft(DOMAINS),
+        name: 'Weekdays',
+        key: 'weekdays',
+        fragments: { ...emptyDeploymentDraft(DOMAINS).fragments, github: 'acme/x' },
+      },
+    })
+
+    await user.click(dayToggle('Sat'))
+    await user.click(dayToggle('Sun'))
+    await user.click(screen.getByRole('button', { name: 'Save' }))
+
+    expect(props.onSubmit).toHaveBeenCalledWith(
+      'weekdays',
+      expect.objectContaining({
+        time: expect.objectContaining({
+          days: ['mon', 'tue', 'wed', 'thu', 'fri'],
+        }),
+      }),
+    )
+  })
+
+  it('writes no days at all when every one is on', async () => {
+    const user = userEvent.setup()
+    const props = renderDeploymentForm({
+      initial: {
+        ...emptyDeploymentDraft(DOMAINS),
+        name: 'Any day',
+        key: 'any-day',
+        fragments: { ...emptyDeploymentDraft(DOMAINS).fragments, github: 'acme/x' },
+      },
+    })
+
+    await user.click(screen.getByRole('button', { name: 'Save' }))
+
+    // A config that never cared about days should not grow a key saying so.
+    expect(props.onSubmit).toHaveBeenCalledWith(
+      'any-day',
+      expect.objectContaining({
+        time: expect.not.objectContaining({ days: expect.anything() }),
+      }),
+    )
+  })
+
+  it('refuses a window with no days at all', async () => {
+    const user = userEvent.setup()
+    const props = renderDeploymentForm({
+      initial: {
+        ...emptyDeploymentDraft(DOMAINS),
+        name: 'Never',
+        key: 'never',
+        days: [],
+        fragments: { ...emptyDeploymentDraft(DOMAINS).fragments, github: 'acme/x' },
+      },
+    })
+
+    await user.click(screen.getByRole('button', { name: 'Save' }))
+
+    expect(
+      screen.getByText('Pick at least one day, or the window can never open.'),
+    ).toBeInTheDocument()
+    expect(props.onSubmit).not.toHaveBeenCalled()
+  })
+})

--- a/tests/schema.test.ts
+++ b/tests/schema.test.ts
@@ -184,3 +184,61 @@ describe('config schema', () => {
     })
   })
 })
+
+describe('days', () => {
+  function withDays(days: unknown) {
+    return {
+      domains: { github: ['*://*.github.com/*'] },
+      sites: { github: { insert: [{ class: 'main', position: 'after' }] } },
+      deployments: {
+        a: {
+          name: 'A',
+          github: 'acme/a',
+          time: {
+            start: '09:00',
+            end: '17:00',
+            timezone: 'Europe/London',
+            days,
+          },
+        },
+      },
+    }
+  }
+
+  it('accepts a list of short day names', () => {
+    expect(validateConfig(withDays(['mon', 'tue'])).valid).toBe(true)
+  })
+
+  it('accepts an empty list, which means every day', () => {
+    expect(validateConfig(withDays([])).valid).toBe(true)
+  })
+
+  it('accepts a window with no days at all', () => {
+    const config = withDays([])
+    delete (config.deployments.a.time as Record<string, unknown>).days
+    expect(validateConfig(config).valid).toBe(true)
+  })
+
+  it('names a long day name where it was written', () => {
+    // "monday" for "mon" is the mistake worth catching, and a config is read
+    // and copied by people - so it is rejected rather than quietly dropped.
+    const result = validateConfig(withDays(['monday']))
+    expect(result.valid).toBe(false)
+    expect(result.errors[0]).toContain('/deployments/a/time/days/0')
+    expect(result.errors[0]).toContain('"mon"')
+  })
+
+  it.each([['MON'], [1], [null]])('rejects %j', (entry) => {
+    expect(validateConfig(withDays([entry])).valid).toBe(false)
+  })
+
+  it('rejects a repeated day', () => {
+    const result = validateConfig(withDays(['mon', 'mon']))
+    expect(result.valid).toBe(false)
+    expect(result.errors[0]).toContain('must not repeat')
+  })
+
+  it('rejects days that are not a list', () => {
+    expect(validateConfig(withDays('mon')).valid).toBe(false)
+  })
+})

--- a/tests/timezones.test.ts
+++ b/tests/timezones.test.ts
@@ -220,3 +220,157 @@ describe('Timezones', () => {
     })
   })
 })
+
+/** 2024-06-03 is a Monday, which every date below is anchored against. */
+const MONDAY = '2024-06-03'
+const TUESDAY = '2024-06-04'
+const FRIDAY = '2024-06-07'
+const SATURDAY = '2024-06-08'
+
+function at(date: string, time: string): Date {
+  return new Date(`${date}T${time}:00`)
+}
+
+describe('windows with days', () => {
+  describe('isOpen', () => {
+    it('is open inside the hours on a day it names', () => {
+      expect(
+        Timezones.isOpen(
+          { start: '09:00', end: '17:00', days: ['mon'] },
+          at(MONDAY, '12:00'),
+        ),
+      ).toBe(true)
+    })
+
+    it('is shut inside the hours on a day it does not', () => {
+      expect(
+        Timezones.isOpen(
+          { start: '09:00', end: '17:00', days: ['mon'] },
+          at(TUESDAY, '12:00'),
+        ),
+      ).toBe(false)
+    })
+
+    it('is shut outside the hours on a day it does name', () => {
+      expect(
+        Timezones.isOpen(
+          { start: '09:00', end: '17:00', days: ['mon'] },
+          at(MONDAY, '18:00'),
+        ),
+      ).toBe(false)
+    })
+
+    it('is open every day when no days are named', () => {
+      for (const date of [MONDAY, TUESDAY, SATURDAY]) {
+        expect(
+          Timezones.isOpen({ start: '09:00', end: '17:00' }, at(date, '12:00')),
+        ).toBe(true)
+      }
+    })
+
+    it('treats an empty list as no constraint', () => {
+      expect(
+        Timezones.isOpen(
+          { start: '09:00', end: '17:00', days: [] },
+          at(SATURDAY, '12:00'),
+        ),
+      ).toBe(true)
+    })
+
+    describe('past midnight', () => {
+      // A Monday 23:00-02:00 window is one window - Monday night - not two
+      // hours of Monday and two hours of Tuesday.
+      const overnight = {
+        start: '23:00',
+        end: '02:00',
+        days: ['mon'] as const,
+      }
+
+      it('is open before midnight on the day it names', () => {
+        expect(Timezones.isOpen(overnight, at(MONDAY, '23:30'))).toBe(true)
+      })
+
+      it('is still open after midnight, on the following morning', () => {
+        expect(Timezones.isOpen(overnight, at(TUESDAY, '01:00'))).toBe(true)
+      })
+
+      it('is shut on the named day before it opens', () => {
+        expect(Timezones.isOpen(overnight, at(MONDAY, '01:00'))).toBe(false)
+      })
+
+      it('is shut on the following evening', () => {
+        expect(Timezones.isOpen(overnight, at(TUESDAY, '23:30'))).toBe(false)
+      })
+    })
+
+    it('refuses a window it cannot read', () => {
+      expect(
+        Timezones.isOpen({ start: 'lunchtime', end: '17:00' }, at(MONDAY, '12:00')),
+      ).toBe(false)
+    })
+  })
+
+  describe('countdownFor', () => {
+    it('counts down to closing while it is open', () => {
+      expect(
+        Timezones.countdownFor(
+          { start: '09:00', end: '17:00', days: ['mon'] },
+          at(MONDAY, '15:30'),
+        ),
+      ).toEqual({ open: true, minutes: 90 })
+    })
+
+    it('counts down to the same day when the opening is still ahead', () => {
+      expect(
+        Timezones.countdownFor(
+          { start: '09:00', end: '17:00', days: ['mon'] },
+          at(MONDAY, '07:00'),
+        ),
+      ).toEqual({ open: false, minutes: 120 })
+    })
+
+    it('counts across days to the next one it opens on', () => {
+      // Friday evening, next window Monday morning: two whole days plus the
+      // rest of Friday night. Counting to "tomorrow" would be a lie.
+      expect(
+        Timezones.countdownFor(
+          { start: '09:00', end: '17:00', days: ['mon'] },
+          at(FRIDAY, '18:00'),
+        ),
+      ).toEqual({ open: false, minutes: 3 * 24 * 60 + 9 * 60 - 18 * 60 })
+    })
+
+    it('skips today once its opening has been and gone', () => {
+      // Monday at 18:00 with a Monday-only window: the next one is a week off.
+      expect(
+        Timezones.countdownFor(
+          { start: '09:00', end: '17:00', days: ['mon'] },
+          at(MONDAY, '18:00'),
+        ),
+      ).toEqual({ open: false, minutes: 7 * 24 * 60 + 9 * 60 - 18 * 60 })
+    })
+
+    it('finds the nearest of several days', () => {
+      expect(
+        Timezones.countdownFor(
+          { start: '09:00', end: '17:00', days: ['mon', 'wed', 'fri'] },
+          at(MONDAY, '18:00'),
+        ),
+      ).toEqual({ open: false, minutes: 2 * 24 * 60 + 9 * 60 - 18 * 60 })
+    })
+
+    it('behaves like the time-only countdown when no days are named', () => {
+      const spec = { start: '09:00', end: '17:00' }
+      expect(Timezones.countdownFor(spec, at(SATURDAY, '18:00'))).toEqual({
+        open: false,
+        minutes: 15 * 60,
+      })
+    })
+
+    it('refuses a window it cannot read', () => {
+      expect(
+        Timezones.countdownFor({ start: '09:00', end: 'teatime' }, at(MONDAY, '12:00')),
+      ).toBeNull()
+    })
+  })
+})

--- a/tests/weekdays.test.ts
+++ b/tests/weekdays.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  WEEKDAYS,
+  dayMessageKey,
+  formatWeekdays,
+  groupWeekdays,
+  WEEK_DISPLAY_ORDER,
+  isEveryDay,
+  isWeekday,
+  previousDay,
+  shiftDays,
+  toWeekdays,
+  weekdayOf,
+} from '../src/app/components/weekdays'
+
+describe('weekdays', () => {
+  it('indexes the way Date.getDay does', () => {
+    // Everything that maps a date onto this list depends on it.
+    expect(WEEKDAYS[0]).toBe('sun')
+    expect(WEEKDAYS).toHaveLength(7)
+  })
+
+  it('shows the week starting on Monday', () => {
+    // A working week, which is what the people configuring one mean by it.
+    expect(WEEK_DISPLAY_ORDER[0]).toBe('mon')
+    expect(WEEK_DISPLAY_ORDER[6]).toBe('sun')
+    expect([...WEEK_DISPLAY_ORDER].sort()).toEqual([...WEEKDAYS].sort())
+  })
+
+  describe('weekdayOf', () => {
+    it.each([
+      ['2024-06-02T12:00:00', 'sun'],
+      ['2024-06-03T12:00:00', 'mon'],
+      ['2024-06-07T12:00:00', 'fri'],
+      ['2024-06-08T12:00:00', 'sat'],
+    ])('reads %s as %s', (iso, expected) => {
+      expect(weekdayOf(new Date(iso))).toBe(expected)
+    })
+  })
+
+  describe('previousDay', () => {
+    it('steps back one', () => {
+      expect(previousDay('tue')).toBe('mon')
+    })
+
+    it('wraps around the start of the week', () => {
+      expect(previousDay('sun')).toBe('sat')
+    })
+  })
+
+  describe('shiftDays', () => {
+    it('leaves a zero shift alone', () => {
+      expect(shiftDays(['mon', 'fri'], 0)).toEqual(['mon', 'fri'])
+    })
+
+    it('moves a set forward', () => {
+      expect(shiftDays(['mon', 'fri'], 1)).toEqual(['tue', 'sat'])
+    })
+
+    it('moves a set backward, wrapping the week', () => {
+      expect(shiftDays(['mon', 'sun'], -1)).toEqual(['sun', 'sat'])
+    })
+  })
+
+  describe('toWeekdays', () => {
+    it('keeps what it recognises, in week order', () => {
+      expect(toWeekdays(['fri', 'mon'])).toEqual(['mon', 'fri'])
+    })
+
+    it('drops duplicates', () => {
+      expect(toWeekdays(['mon', 'mon'])).toEqual(['mon'])
+    })
+
+    it.each([
+      [['monday']],
+      [['MON']],
+      [[1]],
+      [[null]],
+      ['mon'],
+      [undefined],
+      [{}],
+    ])('reads %j as no constraint', (value) => {
+      expect(toWeekdays(value)).toEqual([])
+    })
+  })
+
+  describe('isEveryDay', () => {
+    it('treats nothing as everything', () => {
+      // An absent list has always meant "any day", and an empty one is far
+      // more likely a mistake than a window that can never open.
+      expect(isEveryDay([])).toBe(true)
+    })
+
+    it('treats all seven as everything', () => {
+      expect(isEveryDay([...WEEKDAYS])).toBe(true)
+    })
+
+    it('treats a subset as a constraint', () => {
+      expect(isEveryDay(['mon'])).toBe(false)
+    })
+  })
+
+  describe('isWeekday', () => {
+    it.each(WEEKDAYS)('accepts %s', (day) => {
+      expect(isWeekday(day)).toBe(true)
+    })
+
+    it.each(['monday', 'Mon', '', 1, null, undefined])(
+      'rejects %j',
+      (value) => {
+        expect(isWeekday(value)).toBe(false)
+      },
+    )
+  })
+})
+
+describe('reading a set of days', () => {
+  const label = (day: string) => day.charAt(0).toUpperCase() + day.slice(1)
+
+  describe('groupWeekdays', () => {
+    it('reads the week starting on Monday', () => {
+      expect(groupWeekdays(['sun', 'mon'])).toEqual([['mon'], ['sun']])
+    })
+
+    it('joins consecutive days into a run', () => {
+      expect(groupWeekdays(['mon', 'tue', 'wed'])).toEqual([
+        ['mon', 'tue', 'wed'],
+      ])
+    })
+
+    it('keeps a gap as a gap', () => {
+      expect(groupWeekdays(['mon', 'wed', 'fri'])).toEqual([
+        ['mon'],
+        ['wed'],
+        ['fri'],
+      ])
+    })
+
+    it('reads a weekend as one run rather than two ends of the week', () => {
+      expect(groupWeekdays(['sat', 'sun'])).toEqual([['sat', 'sun']])
+    })
+  })
+
+  describe('formatWeekdays', () => {
+    it.each([
+      [['mon', 'tue', 'wed', 'thu'], 'Mon–Thu'],
+      [['mon', 'tue', 'wed', 'thu', 'fri'], 'Mon–Fri'],
+      [['mon', 'wed', 'fri'], 'Mon, Wed, Fri'],
+      [['mon'], 'Mon'],
+      // Two is listed rather than ranged: no shorter, and nothing to expand.
+      [['sat', 'sun'], 'Sat, Sun'],
+      [['mon', 'tue', 'wed', 'sat'], 'Mon–Wed, Sat'],
+    ])('reads %j as %s', (days, expected) => {
+      expect(formatWeekdays(days as never, label as never)).toBe(expected)
+    })
+
+    it('says nothing when every day is included', () => {
+      // There is no constraint to report, so reporting one would be noise.
+      expect(formatWeekdays([], label as never)).toBe('')
+      expect(formatWeekdays([...WEEKDAYS], label as never)).toBe('')
+    })
+  })
+
+  describe('dayMessageKey', () => {
+    it('names the catalogue entry for a day', () => {
+      expect(dayMessageKey('mon')).toBe('l10nDayMon')
+      expect(dayMessageKey('sun')).toBe('l10nDaySun')
+    })
+  })
+})


### PR DESCRIPTION
"No deploys on Fridays" is the rule almost every team has, and until now there was nowhere to write it down. A window was a time of day and nothing else, so the extension would cheerfully report a Saturday morning as open.

```json
"time": {
  "start": "09:00",
  "end": "17:00",
  "timezone": "Europe/London",
  "days": ["mon", "tue", "wed", "thu", "fri"]
}
```

Absent by default, which is what every config written before today means and goes on meaning. Short names rather than numbers because this file is hand-edited and passed between people: `["mon"]` says what it means and `[1]` starts an argument about whether weeks begin on Sunday.

## Three things that needed deciding

**A day is when the window opens.** A `23:00`–`02:00` window on Monday is Monday night — one window, still Monday's, when it is 01:00 on Tuesday. Getting that backwards would split every overnight window in half and put the second half on a day nobody chose.

**The days move with the hours across a timezone.** Only the clock face survived the conversion to the viewer's zone, so a Tokyo Monday arrived in Los Angeles keeping its hours and quietly dropping the fact that it is Sunday afternoon there. `Timezones.dayShift` measures the move and the days go with it, so the notice reports the viewer's own calendar rather than the config author's.

**The countdown had to count further than tomorrow.** It wrapped within a day — correct until Friday evening, when the honest answer is "3d 15h" and not a confident lie about the morning. It now walks forward through the week to the next day the window actually opens, and the duration grew a days unit. Two units at most: the minutes on the end of a three day wait are noise.

## The signature change

`canDeploy`, `statusText` and `countdownText` now take the window rather than two loose strings. Days arrived after every one of their call sites, and `(start, end)` is a signature all of them would have gone on satisfying while silently ignoring the days. Changing it made the compiler find them instead — which it did, all nine.

## What it looks like

Notice, on a weekday-only window:

```
DEPLOYMENT WINDOW  Mon–Fri  09:00 – 17:00  Europe/London   CURRENT TIME  11:21:53
```

Consecutive days collapse into a range — "Mon–Fri" is one fact where "Mon, Tue, Wed, Thu, Fri" is five. A run of two is listed rather than ranged, since "Sat, Sun" is no shorter than "Sat–Sun" and asks the reader to expand nothing.

The form gets a row of day toggles, starting with all seven on. Unticking all of them is refused: a window with no days can never open, which is never what was meant.

## Verification

Full gate green: typecheck, lint, 171 locale messages, **782 unit tests across 28 files**, manifest, bundle, payload, **36 e2e**.

Screenshotted against a real loaded extension, which incidentally validated the cross-day countdown on live data: taken on a Tuesday, a Mon/Wed/Fri window correctly reported "Opens in 22h 39m" — Wednesday at 10:00, not a wrapped answer about tomorrow.

Two notes:

The payload check reports the content script at **100.9 kB**, up from 92.4 kB, against the 128 kB budget. That is the day model and the formatter, and it is the number the budget exists to keep visible.

`check-locales` caught the day labels being assembled from the day name, which made them invisible to it — a message key nothing can verify is one that breaks quietly when it is renamed. They are spelled out now. That is the second time that check has paid for itself.

## Not in this

Dated freezes — "frozen 20 Dec – 2 Jan" — are a different kind of rule: an override that suspends a window rather than a property of it. Worth doing, worth doing separately.
