### PR TITLE
Dated freezes, and the notice that stopped fitting because of them

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ starts on, and the days move with the hours when the window is written in
 another timezone. When the next one is days away the countdown says "Opens in
 2d 4h" rather than pretending it is tomorrow.
 
+A **freeze** covers a run of calendar days when nothing ships, whatever the
+window says — a Christmas change freeze, or a conference week. While one is on
+the status reads "Deployment frozen", the countdown says when it lifts rather
+than when the window next opens, and the reason is shown beside it.
+
 A **shared config** can be pointed at a JSON file on an https address, for a
 team that deploys the same projects to the same windows. It is fetched hourly
 and merged *underneath* everything configured locally, so any single entry can
@@ -184,6 +189,7 @@ src/
     components/          DW (resolution), Notice (injection), Timezones, helpers
                          Markdown lives here, behind a dynamic import
                          weekdays.ts is the day-of-week model
+                         freezes.ts is the dated-freeze model
     config/              Storage access, types, validation, shared config
     matching/            Chrome match-pattern implementation
   ui/

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -3,6 +3,10 @@
     "message": "Deployment window closed",
     "description": "Statement that the deployment window has closed."
   },
+  "l10nDeploymentFrozen": {
+    "message": "Deployment frozen",
+    "description": "Status when a dated freeze is in force."
+  },
   "l10nDeploymentOpen": {
     "message": "Deployment window open",
     "description": "Statement that the deployment window is open."
@@ -682,5 +686,41 @@
   "l10nDaysRequired": {
     "message": "Pick at least one day, or the window can never open.",
     "description": "Error when every day has been unticked."
+  },
+  "l10nFrozenUntil": {
+    "message": "Frozen until",
+    "description": "Precedes the date a freeze lifts."
+  },
+  "l10nFreezes": {
+    "message": "Freezes",
+    "description": "Label for the list of dated freezes."
+  },
+  "l10nFreezesHint": {
+    "message": "Dates when nothing ships, whatever the window says. Both days are included.",
+    "description": "Hint for the freeze list."
+  },
+  "l10nFreezeFrom": {
+    "message": "From",
+    "description": "Label for the first day of a freeze."
+  },
+  "l10nFreezeTo": {
+    "message": "To",
+    "description": "Label for the last day of a freeze."
+  },
+  "l10nFreezeReason": {
+    "message": "Reason",
+    "description": "Label for why a freeze is in place."
+  },
+  "l10nAddFreeze": {
+    "message": "Add freeze",
+    "description": "Button that adds a dated freeze."
+  },
+  "l10nInvalidDate": {
+    "message": "Use a real date, as YYYY-MM-DD.",
+    "description": "Error when a freeze date cannot be read."
+  },
+  "l10nFreezeBackwards": {
+    "message": "The last day cannot be before the first.",
+    "description": "Error when a freeze range ends before it starts."
   }
 }

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -15,9 +15,9 @@
     "message": "Deployment window",
     "description": "What is the original deployment window."
   },
-  "l10nYourTimezone": {
-    "message": "Your timezone",
-    "description": "What is the deployment window in your local timezone."
+  "l10nSetIn": {
+    "message": "Set in",
+    "description": "Precedes the timezone a window was configured in, e.g. \"Set in Europe/Zurich\"."
   },
   "l10nCurrentTime": {
     "message": "Current time",
@@ -722,5 +722,9 @@
   "l10nFreezeBackwards": {
     "message": "The last day cannot be before the first.",
     "description": "Error when a freeze range ends before it starts."
+  },
+  "l10nConfig": {
+    "message": "Config",
+    "description": "Groups the shared config and JSON config panels."
   }
 }

--- a/src/app/components/DW.ts
+++ b/src/app/components/DW.ts
@@ -8,6 +8,12 @@ import type {
 import { matchesAny } from '../matching/MatchPattern'
 import { Methods } from './Methods'
 import { Timezones, type WindowSpec, isValidTimezone } from './Timezones'
+import {
+  type ActiveFreeze,
+  activeFreeze,
+  toFreezes,
+  todayIn,
+} from './freezes'
 import { shiftDays, toWeekdays } from './weekdays'
 
 const DEFAULT_TIME = '00:00'
@@ -161,6 +167,13 @@ export class DW {
     const startTime = new Timezones(start, timezone)
     const endTime = new Timezones(end, timezone)
     const days = toWeekdays(time?.days)
+    // Against the window's own calendar, not the viewer's: a freeze is written
+    // by the same people who wrote the window, and 20 December means their
+    // 20 December.
+    const freeze = activeFreeze(
+      toFreezes(deployment.freezes),
+      todayIn(startTime.getOriginalTimezone()),
+    )
 
     return {
       original: {
@@ -168,6 +181,7 @@ export class DW {
         end: endTime.toOriginalTime(),
         timezone: endTime.getOriginalTimezone(),
         days,
+        freeze,
       },
       local: {
         start: startTime.toLocalTime(),
@@ -175,6 +189,7 @@ export class DW {
         timezone: endTime.getLocalTimezone(),
         // Shifted by the *start*, because that is the moment a day names.
         days: shiftDays(days, startTime.dayShift()),
+        freeze,
       },
     }
   }
@@ -189,9 +204,37 @@ export class DW {
   }
 
   static statusText(window: WindowSpec): string {
+    if (window.freeze) {
+      return Methods.i18n('l10nDeploymentFrozen')
+    }
     return DW.canDeploy(window)
       ? Methods.i18n('l10nDeploymentOpen')
       : Methods.i18n('l10nDeploymentClosed')
+  }
+
+  /**
+   * "Frozen until 3 Jan".
+   *
+   * The date the freeze lifts rather than its last frozen day: the question
+   * being answered is when deploying resumes, and "frozen until the 2nd" and
+   * "frozen through the 2nd" are a day apart in most people's reading.
+   */
+  static freezeText(freeze: ActiveFreeze): string {
+    return `${Methods.i18n('l10nFrozenUntil')} ${DW.shortDate(freeze.until)}`
+  }
+
+  /** A `YYYY-MM-DD` date as the viewer's locale writes a day and a month. */
+  private static shortDate(date: string): string {
+    const [year, month, day] = date.split('-').map(Number)
+    if (!year || !month || !day) {
+      return date
+    }
+    // Built from the parts rather than parsed: `new Date('2027-01-03')` is
+    // midnight UTC, which is the previous day for anyone west of it.
+    return new Date(year, month - 1, day).toLocaleDateString(undefined, {
+      day: 'numeric',
+      month: 'short',
+    })
   }
 
   /**
@@ -203,6 +246,10 @@ export class DW {
    * unconditionally.
    */
   static countdownText(window: WindowSpec): string {
+    if (window.freeze) {
+      return DW.freezeText(window.freeze)
+    }
+
     const countdown = Timezones.countdownFor(window)
     if (!countdown) {
       return ''

--- a/src/app/components/Notice.ts
+++ b/src/app/components/Notice.ts
@@ -305,11 +305,41 @@ export class Notice {
         ? `<p class="frozen">${t(freeze.reason)}</p>`
         : ''
 
+    // Your own window first, and without naming your zone: it is the one you
+    // act on, and you already know where you are. What the config actually
+    // says follows as provenance - useful for checking the notice against what
+    // the team agreed, and not the thing being read at a glance.
+    const { local, original } = timeObj
+    const localDays = daysLabel(local.days)
+    const sourceDays = daysLabel(original.days)
+
     const times = notesOnly
       ? ''
       : `<dl class="rows">
-          ${Notice.row(Methods.i18n('l10nDeploymentWindow'), timeObj.original)}
-          ${showLocal ? Notice.row(Methods.i18n('l10nYourTimezone'), timeObj.local) : ''}
+          <div class="row">
+            <dt>${Methods.i18n('l10nDeploymentWindow')}</dt>
+            <dd>
+              ${localDays ? `<span class="days">${t(localDays)}</span>` : ''}
+              <span class="time">${t(local.start)} &ndash; ${t(local.end)}</span>
+            </dd>
+          </div>
+          ${
+            showLocal
+              ? `<div class="row row-quiet">
+                  <dt>${Methods.i18n('l10nSetIn')} ${t(original.timezone)}</dt>
+                  <dd>
+                    ${
+                      // Only when the conversion actually moved them; saying
+                      // "Mon-Thu" twice was most of what made this too long.
+                      sourceDays && sourceDays !== localDays
+                        ? `<span class="days">${t(sourceDays)}</span>`
+                        : ''
+                    }
+                    <span class="time">${t(original.start)} &ndash; ${t(original.end)}</span>
+                  </dd>
+                </div>`
+              : ''
+          }
           <div class="row">
             <dt>${Methods.i18n('l10nCurrentTime')}</dt>
             <dd><span class="time clock">${t(Timezones.getCurrentTime())}</span></dd>
@@ -372,21 +402,6 @@ export class Notice {
     this.markPath?.setAttribute('stroke-width', String(glyph.width))
   }
 
-  private static row(
-    label: string,
-    window: ResolvedDeployment['timeObj']['original'],
-  ): string {
-    const t = TextFormatter.stripTags
-    const days = daysLabel(window.days)
-    return `<div class="row">
-      <dt>${label}</dt>
-      <dd>
-        ${days ? `<span class="days">${t(days)}</span>` : ''}
-        <span class="time">${t(window.start)} &ndash; ${t(window.end)}</span>
-        <span class="zone">${t(window.timezone)}</span>
-      </dd>
-    </div>`
-  }
 
   /**
    * Play the attention animation once.

--- a/src/app/components/Notice.ts
+++ b/src/app/components/Notice.ts
@@ -95,6 +95,8 @@ export class Notice {
     if (this.deployment.notesOnly) {
       return 'notes'
     }
+    // A freeze is not a fourth colour: red already means "not today", and the
+    // reason line beside it is what says which kind of not-today this is.
     return DW.canDeploy(this.deployment.timeObj.local) ? 'open' : 'closed'
   }
 
@@ -294,6 +296,15 @@ export class Notice {
     // room it does not need is room it should not take.
     const showLocal = timeObj.original.timezone !== timeObj.local.timezone
 
+    // Only the reason. The pill already says "Deployment frozen" and the head
+    // already says until when, so repeating either here would be the notice
+    // saying the same thing three times in three places.
+    const freeze = notesOnly ? null : timeObj.original.freeze
+    const frozen =
+      freeze && freeze.reason
+        ? `<p class="frozen">${t(freeze.reason)}</p>`
+        : ''
+
     const times = notesOnly
       ? ''
       : `<dl class="rows">
@@ -317,7 +328,7 @@ export class Notice {
         </div>`
       : ''
 
-    return `<div class="head">${heading}</div>${times}${details}`
+    return `<div class="head">${heading}</div>${frozen}${times}${details}`
   }
 
   /** "Closes in 2h 10m", for the head. */

--- a/src/app/components/Timezones.ts
+++ b/src/app/components/Timezones.ts
@@ -7,6 +7,7 @@ dayjs.extend(utc)
 dayjs.extend(customParseFormat)
 dayjs.extend(timezone)
 
+import type { ActiveFreeze } from './freezes'
 import {
   WEEKDAYS,
   type Weekday,
@@ -51,6 +52,8 @@ export interface WindowSpec {
   end: string
   /** Days the window opens on. Empty means every day. */
   days?: readonly Weekday[]
+  /** A freeze covering today, which shuts the window whatever the hours say. */
+  freeze?: ActiveFreeze | null
 }
 
 export interface CurrentDate {
@@ -281,6 +284,12 @@ export class Timezones {
    * hours after midnight belong to the day before.
    */
   static isOpen(spec: WindowSpec, at: Date = new Date()): boolean {
+    // A freeze is the whole answer: there is no hour of a frozen day when
+    // deploying is allowed, so nothing below it needs asking.
+    if (spec.freeze) {
+      return false
+    }
+
     const start = toMinutesOfDay(spec.start)
     const end = toMinutesOfDay(spec.end)
     if (start === null || end === null) {
@@ -325,6 +334,12 @@ export class Timezones {
     }
 
     const now = at.getHours() * 60 + at.getMinutes()
+
+    // A frozen window has no next opening to count down to; when it lifts is
+    // a date, and DW words it as one.
+    if (spec.freeze) {
+      return null
+    }
 
     if (Timezones.isOpen(spec, at)) {
       return { open: true, minutes: (end - now + MINUTES_PER_DAY) % MINUTES_PER_DAY }

--- a/src/app/components/freezes.ts
+++ b/src/app/components/freezes.ts
@@ -1,0 +1,155 @@
+import dayjs from 'dayjs'
+import utc from 'dayjs/plugin/utc'
+import timezone from 'dayjs/plugin/timezone'
+
+// Registered here rather than relied on from elsewhere. `dayjs.extend` mutates
+// one shared instance, so this worked for as long as Timezones.ts happened to
+// be imported first - and `.tz()` silently returns the wrong day when it has
+// not been. A test that imported only this module is what found it.
+dayjs.extend(utc)
+dayjs.extend(timezone)
+
+/**
+ * Dated freezes: stretches of the calendar when nothing ships, whatever the
+ * window says.
+ *
+ * A freeze is not a property of a window, which is why it does not live inside
+ * `time`. A window describes when deploying is allowed in the ordinary run of
+ * things; a freeze suspends that for a fortnight in December because the people
+ * who would fix it are not there. One is a rule, the other overrides it.
+ *
+ * Dates are plain `YYYY-MM-DD` and both ends are inclusive, so 20 December to
+ * 2 January is frozen for the whole of both days. They are compared as strings,
+ * which works because an ISO date sorts chronologically - and avoids parsing a
+ * date only to compare it against another one.
+ */
+
+/** `YYYY-MM-DD`, the only date shape this accepts. */
+const ISO_DATE = /^(\d{4})-(\d{2})-(\d{2})$/
+
+export interface Freeze {
+  /** First frozen day, inclusive. */
+  from: string
+  /** Last frozen day, inclusive. */
+  to: string
+  /** Why, shown wherever the freeze is reported. */
+  reason?: string
+}
+
+export interface ActiveFreeze {
+  /** The day the freeze lifts, i.e. the day after `to`. */
+  until: string
+  /** The last frozen day, as configured. */
+  to: string
+  reason: string
+}
+
+/**
+ * A real calendar date, not just the right shape.
+ *
+ * `2026-02-30` matches the pattern and is not a day. Left as a string
+ * comparison everywhere else, but a range that can never contain today is
+ * worth naming while somebody is looking at the editor.
+ */
+export function isCalendarDate(value: unknown): value is string {
+  if (typeof value !== 'string') {
+    return false
+  }
+  const parts = ISO_DATE.exec(value)
+  if (!parts) {
+    return false
+  }
+  const [, year, month, day] = parts
+  const date = new Date(Number(year), Number(month) - 1, Number(day))
+  return (
+    date.getFullYear() === Number(year) &&
+    date.getMonth() === Number(month) - 1 &&
+    date.getDate() === Number(day)
+  )
+}
+
+/** Read stored freezes, dropping anything that is not a usable range. */
+export function toFreezes(value: unknown): Freeze[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  const freezes: Freeze[] = []
+  for (const entry of value) {
+    if (!entry || typeof entry !== 'object') {
+      continue
+    }
+    const { from, to, reason } = entry as Partial<Freeze>
+    if (!isCalendarDate(from) || !isCalendarDate(to) || to < from) {
+      continue
+    }
+    freezes.push({
+      from,
+      to,
+      ...(typeof reason === 'string' && reason.trim()
+        ? { reason: reason.trim() }
+        : {}),
+    })
+  }
+  return freezes
+}
+
+/**
+ * Today's date in `zone`, as `YYYY-MM-DD`.
+ *
+ * A freeze is a run of calendar days, and which day it is depends on where you
+ * are standing. The window's own timezone is the one that decides: a freeze is
+ * written by the same people who wrote the window, against the same calendar.
+ */
+export function todayIn(zone: string, at: Date = new Date()): string {
+  try {
+    return dayjs(at).tz(zone).format('YYYY-MM-DD')
+  } catch {
+    return dayjs(at).format('YYYY-MM-DD')
+  }
+}
+
+/** The day after `date`, as `YYYY-MM-DD`. */
+export function dayAfter(date: string): string {
+  const parts = ISO_DATE.exec(date)
+  if (!parts) {
+    return date
+  }
+  const [, year, month, day] = parts
+  const next = new Date(Number(year), Number(month) - 1, Number(day) + 1)
+  return [
+    String(next.getFullYear()).padStart(4, '0'),
+    String(next.getMonth() + 1).padStart(2, '0'),
+    String(next.getDate()).padStart(2, '0'),
+  ].join('-')
+}
+
+/**
+ * The freeze covering `today`, if any.
+ *
+ * The one that ends latest wins where two overlap, so the answer to "when can
+ * I deploy again" is not shortened by a freeze that is about to lift while
+ * another one runs on.
+ */
+export function activeFreeze(
+  freezes: readonly Freeze[],
+  today: string,
+): ActiveFreeze | null {
+  let latest: Freeze | null = null
+  for (const freeze of freezes) {
+    if (freeze.from <= today && today <= freeze.to) {
+      if (!latest || freeze.to > latest.to) {
+        latest = freeze
+      }
+    }
+  }
+
+  if (!latest) {
+    return null
+  }
+  return {
+    until: dayAfter(latest.to),
+    to: latest.to,
+    reason: latest.reason ?? '',
+  }
+}

--- a/src/app/config/schema.ts
+++ b/src/app/config/schema.ts
@@ -16,6 +16,7 @@ import type { DeploymentWindowsConfig } from './types'
  * "must ..." message - so they stay familiar and are safe to show verbatim.
  */
 
+import { isCalendarDate } from '../components/freezes'
 import { WEEKDAYS, isWeekday } from '../components/weekdays'
 import { isCssSpacing } from './css'
 
@@ -28,6 +29,7 @@ const DEPLOYMENT_KNOWN_KEYS = new Set([
   'name',
   'notes',
   'time',
+  'freezes',
   'case-sensitive',
   'notes-only',
 ])
@@ -266,6 +268,57 @@ function validateDays(value: unknown, path: string, errors: Errors): void {
   })
 }
 
+/**
+ * Dated freezes on a deployment.
+ *
+ * A range that ends before it starts is refused rather than ignored: it looks
+ * like a rule, it can never contain a day, and the only symptom of getting it
+ * backwards would be a freeze that silently never happens.
+ */
+function validateFreezes(value: unknown, path: string, errors: Errors): void {
+  if (!Array.isArray(value)) {
+    errors.type(path, 'array')
+    return
+  }
+
+  value.forEach((entry, index) => {
+    const at = `${path}/${String(index)}`
+    if (!isPlainObject(entry)) {
+      errors.type(at, 'object')
+      return
+    }
+
+    for (const key of ['from', 'to'] as const) {
+      if (!(key in entry)) {
+        errors.required(at, key)
+      } else if (!isCalendarDate(entry[key])) {
+        errors.add(
+          join(at, key),
+          'must be a real date written as YYYY-MM-DD',
+        )
+      }
+    }
+
+    if (
+      isCalendarDate(entry.from) &&
+      isCalendarDate(entry.to) &&
+      entry.to < entry.from
+    ) {
+      errors.add(at, 'must not end before it starts')
+    }
+
+    if ('reason' in entry && typeof entry.reason !== 'string') {
+      errors.type(join(at, 'reason'), 'string')
+    }
+
+    for (const extra of Object.keys(entry)) {
+      if (extra !== 'from' && extra !== 'to' && extra !== 'reason') {
+        errors.add(at, `must NOT have additional properties ('${extra}')`)
+      }
+    }
+  })
+}
+
 function validateDeployments(value: unknown, path: string, errors: Errors): void {
   if (!isPlainObject(value)) {
     errors.type(path, 'object')
@@ -292,6 +345,9 @@ function validateDeployments(value: unknown, path: string, errors: Errors): void
     }
     if ('time' in deployment) {
       validateTime(deployment.time, join(at, 'time'), errors)
+    }
+    if ('freezes' in deployment) {
+      validateFreezes(deployment.freezes, join(at, 'freezes'), errors)
     }
 
     // Anything else is a per-domain url fragment and must be a string.

--- a/src/app/config/types.ts
+++ b/src/app/config/types.ts
@@ -3,6 +3,7 @@
  * deployment that the notice and popup render from.
  */
 
+import type { ActiveFreeze, Freeze } from '../components/freezes'
 import type { Weekday } from '../components/weekdays'
 
 export type InsertPosition = 'before' | 'after'
@@ -59,9 +60,17 @@ export interface DeploymentConfig {
   name?: string
   notes?: string
   time?: DeploymentTime
+  /**
+   * Stretches of the calendar when nothing ships, whatever the window says.
+   *
+   * Not part of `time` on purpose: a window says when deploying is allowed in
+   * the ordinary run of things, and a freeze suspends that. One is a rule, the
+   * other overrides it.
+   */
+  freezes?: Freeze[]
   'case-sensitive'?: boolean
   'notes-only'?: boolean
-  [domainKey: string]: string | boolean | DeploymentTime | undefined
+  [domainKey: string]: string | boolean | DeploymentTime | Freeze[] | undefined
 }
 
 export interface DeploymentWindowsConfig {
@@ -84,6 +93,13 @@ export interface ResolvedTimeWindow {
    * calendar actually says.
    */
   days: Weekday[]
+  /**
+   * The freeze covering today, or null.
+   *
+   * Carried on the window rather than beside it so that anything asking "is
+   * this open" is holding everything that decides the answer.
+   */
+  freeze: ActiveFreeze | null
 }
 
 export interface ResolvedTimes {
@@ -110,7 +126,7 @@ export interface ResolvedDeployment {
   /** Insert locations and classes for the matched domain. */
   domainInfo: SiteConfig
   timeObj: ResolvedTimes
-  /** Localised "open"/"closed" text. */
+  /** Localised "open"/"closed"/"frozen" text. */
   status: string
   canDeploy: boolean
 }

--- a/src/documents/HowToUse.md
+++ b/src/documents/HowToUse.md
@@ -145,6 +145,23 @@ not what the person who wrote the config was looking at.
 
 When the next window is days away, the countdown says so: "Opens in 2d 4h".
 
+### Freezes
+
+A **freeze** is a run of calendar days when nothing ships, whatever the window
+says — a Christmas change freeze, a conference week, the fortnight the people
+who would fix it are away.
+
+Add one with a first day, a last day and, if it helps, a reason. Both days are
+included, so 20 December to 2 January is frozen for the whole of both. While it
+is on, the status reads "Deployment frozen", the countdown says when it lifts
+rather than when the window next opens, and the reason is shown beside it.
+
+Dates are read against the window's own timezone — the same calendar the window
+was written in.
+
+A freeze beats everything else. It does not matter what the hours say or which
+days are ticked.
+
 ---
 
 ## Editing the JSON directly
@@ -189,7 +206,14 @@ The stored config has three parts: `domains`, `sites` and `deployments`.
                 "timezone": "Europe/Paris",
                 "days": ["mon", "tue", "wed", "thu"]
             },
-            "notes": "Deploys need **two** approvals."
+            "notes": "Deploys need **two** approvals.",
+            "freezes": [
+                {
+                    "from": "2026-12-20",
+                    "to": "2027-01-02",
+                    "reason": "Christmas change freeze"
+                }
+            ]
         }
     }
 }
@@ -230,3 +254,7 @@ time.time_data.start|time[24]|24 hour time the window opens, e.g. `09:00`
 time.time_data.end|time[24]|24 hour time the window closes; may be earlier than the start to run past midnight
 time.time_data.timezone|string|An [IANA timezone](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) such as `Europe/London`
 time.time_data.days|array[day]|Days the window opens on, e.g. `["mon","tue","wed","thu","fri"]`. Leave it out for every day
+freezes|array[freeze_data]|Runs of days when nothing ships, whatever the window says
+freezes.freeze_data.from|date|First frozen day, `YYYY-MM-DD`, included
+freezes.freeze_data.to|date|Last frozen day, `YYYY-MM-DD`, included
+freezes.freeze_data.reason|string|Optional, shown wherever the freeze is reported

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -66,7 +66,8 @@
   background: var(--dw-success-soft);
 }
 
-.dw-pill-closed {
+.dw-pill-closed,
+.dw-pill-frozen {
   color: var(--dw-danger);
   background: var(--dw-danger-soft);
 }
@@ -96,7 +97,8 @@
   color: var(--dw-success);
 }
 
-.dw-countdown-closed {
+.dw-countdown-closed,
+.dw-countdown-frozen {
   color: var(--dw-danger);
 }
 

--- a/src/styles/forms.css
+++ b/src/styles/forms.css
@@ -417,3 +417,26 @@
   outline: 2px solid var(--dw-focus);
   outline-offset: 2px;
 }
+
+/* ------------------------------------------------------------------ */
+/* freezes                                                             */
+/* ------------------------------------------------------------------ */
+
+/* Why the freeze is on - and only that. The status pill says what is happening
+   and the countdown says until when, so this is the one thing neither of them
+   can say. Shown above the hours it overrides: reading the times first only to
+   be told they do not apply is the wrong way round. */
+.dw-frozen {
+  margin: 0 0 var(--dw-space-3);
+  padding: 7px 12px;
+  font-size: 0.85rem;
+  font-weight: 560;
+  color: var(--dw-danger);
+  background: var(--dw-danger-soft);
+  border-radius: var(--dw-radius-sm);
+}
+
+/* Two dates and a reason, rather than one field and a button. */
+.dw-repeat-row-freeze {
+  grid-template-columns: minmax(120px, 0.7fr) minmax(120px, 0.7fr) 1fr auto;
+}

--- a/src/styles/notice.css
+++ b/src/styles/notice.css
@@ -342,6 +342,13 @@
 /* the times                                                           */
 /* ------------------------------------------------------------------ */
 
+/* Where the window was written, as against where it is being read. Quieter
+   than the row above it, because it is provenance rather than the answer. */
+.row-quiet dt,
+.row-quiet dd {
+  opacity: 0.72;
+}
+
 /* Which days the window opens on, when it is not all of them. Reads ahead of
    the hours because it is the coarser fact: there is no point reading 09:00
    before knowing whether today is one of the days at all. */

--- a/src/styles/notice.css
+++ b/src/styles/notice.css
@@ -324,6 +324,20 @@
   opacity: 1;
 }
 
+/* Why the freeze is on - and only that. The pill says what is happening and
+   the head says until when, so this is the one thing neither of them can say.
+   Tinted with the card's own tone rather than a colour of its own: the tone
+   already means "not today". */
+.frozen {
+  margin: 0;
+  padding: 7px 12px;
+  font-size: 13px;
+  font-weight: 560;
+  color: var(--dw-tone);
+  background: var(--dw-tone-soft);
+  border-radius: 8px;
+}
+
 /* ------------------------------------------------------------------ */
 /* the times                                                           */
 /* ------------------------------------------------------------------ */

--- a/src/styles/options.css
+++ b/src/styles/options.css
@@ -303,11 +303,15 @@ body {
   color: var(--dw-text-muted);
 }
 
+/* Cards match the tallest in their row rather than each ending wherever their
+   own content does. Two sites side by side with a different number of insert
+   rules used to leave their Edit and Delete buttons at different heights,
+   which reads as a mistake rather than as a difference in content. */
 .dw-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
   gap: var(--dw-space-4);
-  align-items: start;
+  align-items: stretch;
 }
 
 .dw-card {
@@ -469,6 +473,9 @@ body {
   align-items: center;
   gap: var(--dw-space-2);
   flex-wrap: wrap;
+  /* Pinned to the bottom of a stretched card, so the row of buttons lines up
+     across the grid however much is above it. */
+  margin-top: auto;
   padding-top: var(--dw-space-3);
   border-top: 1px solid var(--dw-border);
 }
@@ -772,10 +779,19 @@ body {
 /* json panel                                                          */
 /* ------------------------------------------------------------------ */
 
-.dw-panel {
+/* Both panels in one frame, divided rather than stacked as separate cards. */
+.dw-panels {
   background: var(--dw-surface);
   border: 1px solid var(--dw-border);
   border-radius: var(--dw-radius-lg);
+  overflow: hidden;
+}
+
+.dw-panel + .dw-panel {
+  border-top: 1px solid var(--dw-border);
+}
+
+.dw-panel {
   overflow: hidden;
 }
 
@@ -784,7 +800,8 @@ body {
   align-items: center;
   gap: var(--dw-space-3);
   width: 100%;
-  padding: var(--dw-space-4);
+  /* Tighter than a card's: these are rows in a list of two, not content. */
+  padding: var(--dw-space-3) var(--dw-space-4);
   font: inherit;
   text-align: left;
   color: inherit;

--- a/src/ui/components/Options.tsx
+++ b/src/ui/components/Options.tsx
@@ -424,15 +424,18 @@ export function Options() {
           )}
         </section>
 
-        <SharedConfigPanel onChanged={() => void reload()} />
+        {/* One block rather than two full-width slabs. Neither is a place you
+            go on purpose - they are the ways in and out of the config, not part
+            of it - so they should not weigh the same as the cards above. */}
+        <section className="dw-panels" aria-label={Methods.i18n('l10nConfig')}>
+          <SharedConfigPanel onChanged={() => void reload()} />
 
-        <JsonPanel
-          config={config}
-          theme={theme.resolved}
-          onApply={(next) =>
-            persist(next, Methods.i18n('l10nSaved'))
-          }
-        />
+          <JsonPanel
+            config={config}
+            theme={theme.resolved}
+            onApply={(next) => persist(next, Methods.i18n('l10nSaved'))}
+          />
+        </section>
       </main>
 
       {dialog?.kind === 'deployment' && (

--- a/src/ui/components/Popup.tsx
+++ b/src/ui/components/Popup.tsx
@@ -130,6 +130,9 @@ function toneFor(deployment: ResolvedDeployment): StatusTone {
   if (deployment.notesOnly) {
     return 'notes'
   }
+  if (deployment.timeObj.local.freeze) {
+    return 'frozen'
+  }
   return DW.canDeploy(deployment.timeObj.local) ? 'open' : 'closed'
 }
 
@@ -223,7 +226,11 @@ function Window({ deployment }: { deployment: ResolvedDeployment }) {
   const localDays = daysLabel(local.days)
 
   return (
-    <dl className="dw-popup-rows">
+    <>
+      {original.freeze?.reason && (
+        <p className="dw-frozen">{original.freeze.reason}</p>
+      )}
+      <dl className="dw-popup-rows">
       <div className="dw-popup-row">
         <dt>
           <ClockIcon size={14} />
@@ -249,7 +256,8 @@ function Window({ deployment }: { deployment: ResolvedDeployment }) {
           </dd>
         </div>
       )}
-    </dl>
+      </dl>
+    </>
   )
 }
 

--- a/src/ui/components/Popup.tsx
+++ b/src/ui/components/Popup.tsx
@@ -220,10 +220,11 @@ function SettingsButton({ compact }: { compact: boolean }) {
 
 function Window({ deployment }: { deployment: ResolvedDeployment }) {
   const { original, local } = deployment.timeObj
-  // The converted window is only worth the space when it actually differs.
-  const showLocal = original.timezone !== local.timezone
-  const originalDays = daysLabel(original.days)
+  // Your own window leads, and does not name your zone; what the config says
+  // follows as provenance, and only when it differs.
+  const showSource = original.timezone !== local.timezone
   const localDays = daysLabel(local.days)
+  const sourceDays = daysLabel(original.days)
 
   return (
     <>
@@ -231,31 +232,33 @@ function Window({ deployment }: { deployment: ResolvedDeployment }) {
         <p className="dw-frozen">{original.freeze.reason}</p>
       )}
       <dl className="dw-popup-rows">
-      <div className="dw-popup-row">
-        <dt>
-          <ClockIcon size={14} />
-          {Methods.i18n('l10nDeploymentWindow')}
-        </dt>
-        <dd>
-          {originalDays && <span className="dw-days">{originalDays}</span>}
-          <span className="dw-mono">
-            {original.start} &ndash; {original.end}
-          </span>
-          <span className="dw-popup-zone">{original.timezone}</span>
-        </dd>
-      </div>
-      {showLocal && (
-        <div className="dw-popup-row dw-popup-row-subtle">
-          <dt>{Methods.i18n('l10nYourTimezone')}</dt>
+        <div className="dw-popup-row">
+          <dt>
+            <ClockIcon size={14} />
+            {Methods.i18n('l10nDeploymentWindow')}
+          </dt>
           <dd>
             {localDays && <span className="dw-days">{localDays}</span>}
             <span className="dw-mono">
               {local.start} &ndash; {local.end}
             </span>
-            <span className="dw-popup-zone">{local.timezone}</span>
           </dd>
         </div>
-      )}
+        {showSource && (
+          <div className="dw-popup-row dw-popup-row-subtle">
+            <dt>
+              {Methods.i18n('l10nSetIn')} {original.timezone}
+            </dt>
+            <dd>
+              {sourceDays !== localDays && sourceDays && (
+                <span className="dw-days">{sourceDays}</span>
+              )}
+              <span className="dw-mono">
+                {original.start} &ndash; {original.end}
+              </span>
+            </dd>
+          </div>
+        )}
       </dl>
     </>
   )

--- a/src/ui/components/common/Countdown.tsx
+++ b/src/ui/components/common/Countdown.tsx
@@ -17,7 +17,7 @@ export function Countdown({ window }: { window: ResolvedTimeWindow }) {
     return null
   }
 
-  const tone = DW.canDeploy(window) ? 'open' : 'closed'
+  const tone = window.freeze ? 'frozen' : DW.canDeploy(window) ? 'open' : 'closed'
   return <span className={`dw-countdown dw-countdown-${tone}`}>{text}</span>
 }
 

--- a/src/ui/components/common/StatusPill.tsx
+++ b/src/ui/components/common/StatusPill.tsx
@@ -2,11 +2,12 @@ import { glyphFor } from '../../../app/glyphs'
 import { Methods } from '../../../app/components/Methods'
 import { StatusMark } from './Icons'
 
-export type StatusTone = 'open' | 'closed' | 'notes' | 'unset'
+export type StatusTone = 'open' | 'closed' | 'frozen' | 'notes' | 'unset'
 
 const LABEL_KEYS: Record<StatusTone, string> = {
   open: 'l10nDeploymentOpen',
   closed: 'l10nDeploymentClosed',
+  frozen: 'l10nDeploymentFrozen',
   notes: 'l10nNotesOnly',
   unset: 'l10nNoWindowSet',
 }

--- a/src/ui/components/dashboard/DeploymentCard.tsx
+++ b/src/ui/components/dashboard/DeploymentCard.tsx
@@ -86,9 +86,12 @@ export function DeploymentCard({
   const notes = typeof deployment.notes === 'string' ? deployment.notes : ''
   const notesHtml = useMarkdown(notes)
   const times = deployment.time ? DW.buildTimes(deployment) : null
-  // The converted window is only worth the space when it actually differs.
-  const showLocal =
+  // Your own window leads, and does not name your zone; what the config says
+  // follows as provenance, and only when it differs.
+  const showSource =
     times !== null && times.original.timezone !== times.local.timezone
+  const localDays = times ? daysLabel(times.local.days) : ''
+  const sourceDays = times ? daysLabel(times.original.days) : ''
 
   return (
     <article className="dw-card" data-status={tone}>
@@ -127,28 +130,24 @@ export function DeploymentCard({
               </span>
             </dt>
             <dd>
-              {daysLabel(times.original.days) && (
-                <span className="dw-days">
-                  {daysLabel(times.original.days)}
-                </span>
-              )}
+              {localDays && <span className="dw-days">{localDays}</span>}
               <span className="dw-mono">
-                {times.original.start} &ndash; {times.original.end}
+                {times.local.start} &ndash; {times.local.end}
               </span>
-              <span className="dw-card-zone">{times.original.timezone}</span>
             </dd>
           </div>
-          {showLocal && (
+          {showSource && (
             <div className="dw-card-row dw-card-row-subtle">
-              <dt>{Methods.i18n('l10nYourTimezone')}</dt>
+              <dt>
+                {Methods.i18n('l10nSetIn')} {times.original.timezone}
+              </dt>
               <dd>
-                {daysLabel(times.local.days) && (
-                  <span className="dw-days">{daysLabel(times.local.days)}</span>
+                {sourceDays !== localDays && sourceDays && (
+                  <span className="dw-days">{sourceDays}</span>
                 )}
                 <span className="dw-mono">
-                  {times.local.start} &ndash; {times.local.end}
+                  {times.original.start} &ndash; {times.original.end}
                 </span>
-                <span className="dw-card-zone">{times.local.timezone}</span>
               </dd>
             </div>
           )}

--- a/src/ui/components/dashboard/DeploymentCard.tsx
+++ b/src/ui/components/dashboard/DeploymentCard.tsx
@@ -34,6 +34,9 @@ export function statusFor(deployment: DeploymentConfig): StatusTone {
     return 'unset'
   }
   const { local } = DW.buildTimes(deployment)
+  if (local.freeze) {
+    return 'frozen'
+  }
   return DW.canDeploy(local) ? 'open' : 'closed'
 }
 
@@ -109,6 +112,9 @@ export function DeploymentCard({
         </div>
       </header>
 
+      {times?.original.freeze?.reason && (
+        <p className="dw-frozen">{times.original.freeze.reason}</p>
+      )}
       {times && (
         <dl className="dw-card-rows">
           <div className="dw-card-row">

--- a/src/ui/components/dashboard/DeploymentForm.tsx
+++ b/src/ui/components/dashboard/DeploymentForm.tsx
@@ -8,6 +8,7 @@ import {
 } from '../../../app/components/weekdays'
 import type { DeploymentConfig } from '../../../app/config/types'
 import Field from '../common/Field'
+import { PlusIcon, TrashIcon } from '../common/Icons'
 import Modal from '../common/Modal'
 import Toggle from '../common/Toggle'
 import {
@@ -52,6 +53,14 @@ export function DeploymentForm({
     if (submitted) {
       setErrors(validateDeploymentDraft(next, takenKeys))
     }
+  }
+
+  const setFreeze = (index: number, patch: Partial<DeploymentDraft['freezes'][number]>) => {
+    update({
+      freezes: draft.freezes.map((freeze, position) =>
+        position === index ? { ...freeze, ...patch } : freeze,
+      ),
+    })
   }
 
   const setName = (name: string) => {
@@ -276,6 +285,89 @@ export function DeploymentForm({
             </Field>
           </fieldset>
         )}
+
+        <fieldset className="dw-fieldset">
+          <legend>{Methods.i18n('l10nFreezes')}</legend>
+          <p className="dw-fieldset-hint">{Methods.i18n('l10nFreezesHint')}</p>
+
+          {draft.freezes.map((freeze, index) => (
+            <div className="dw-repeat-row dw-repeat-row-freeze" key={index}>
+              <Field
+                label={Methods.i18n('l10nFreezeFrom')}
+                error={shown(`freeze.${index}.from`)}
+              >
+                {({ id }) => (
+                  <input
+                    id={id}
+                    className="dw-input"
+                    type="date"
+                    value={freeze.from}
+                    onChange={(event) =>
+                      setFreeze(index, { from: event.target.value })
+                    }
+                  />
+                )}
+              </Field>
+              <Field
+                label={Methods.i18n('l10nFreezeTo')}
+                error={shown(`freeze.${index}.to`)}
+              >
+                {({ id }) => (
+                  <input
+                    id={id}
+                    className="dw-input"
+                    type="date"
+                    value={freeze.to}
+                    onChange={(event) =>
+                      setFreeze(index, { to: event.target.value })
+                    }
+                  />
+                )}
+              </Field>
+              <Field label={Methods.i18n('l10nFreezeReason')}>
+                {({ id }) => (
+                  <input
+                    id={id}
+                    className="dw-input"
+                    type="text"
+                    placeholder="Christmas change freeze"
+                    value={freeze.reason ?? ''}
+                    onChange={(event) =>
+                      setFreeze(index, { reason: event.target.value })
+                    }
+                  />
+                )}
+              </Field>
+              <button
+                type="button"
+                className="dw-icon-button dw-icon-button-danger"
+                aria-label={`${Methods.i18n('l10nRemove')} ${Methods.i18n('l10nFreezes')} ${index + 1}`}
+                onClick={() =>
+                  update({
+                    freezes: draft.freezes.filter(
+                      (_, position) => position !== index,
+                    ),
+                  })
+                }
+              >
+                <TrashIcon size={15} />
+              </button>
+            </div>
+          ))}
+
+          <button
+            type="button"
+            className="dw-button dw-button-ghost dw-button-small"
+            onClick={() =>
+              update({
+                freezes: [...draft.freezes, { from: '', to: '', reason: '' }],
+              })
+            }
+          >
+            <PlusIcon size={14} />
+            {Methods.i18n('l10nAddFreeze')}
+          </button>
+        </fieldset>
 
         <fieldset className="dw-fieldset">
           <legend>{Methods.i18n('l10nUrlFragments')}</legend>

--- a/src/ui/components/dashboard/drafts.ts
+++ b/src/ui/components/dashboard/drafts.ts
@@ -1,6 +1,11 @@
 import { Methods } from '../../../app/components/Methods'
 import { Timezones, isValidTimezone } from '../../../app/components/Timezones'
 import {
+  type Freeze,
+  isCalendarDate,
+  toFreezes,
+} from '../../../app/components/freezes'
+import {
   WEEKDAYS,
   type Weekday,
   isEveryDay,
@@ -32,6 +37,7 @@ export const DEPLOYMENT_RESERVED_KEYS = new Set([
   'name',
   'notes',
   'time',
+  'freezes',
   'case-sensitive',
   'notes-only',
 ])
@@ -51,6 +57,8 @@ export interface DeploymentDraft {
    * reads as a window that never opens.
    */
   days: Weekday[]
+  /** Dated freezes, as typed. Blank rows are dropped rather than saved. */
+  freezes: Freeze[]
   /** domain key -> url fragment, one entry per configured site. */
   fragments: Record<string, string>
 }
@@ -95,6 +103,10 @@ export function toDeploymentDraft(
     end: time?.end ?? '17:00',
     timezone: time?.timezone ?? Timezones.findLocalTimezone(),
     days: stored.length > 0 ? stored : [...WEEKDAYS],
+    freezes: toFreezes(deployment.freezes).map((freeze) => ({
+      ...freeze,
+      reason: freeze.reason ?? '',
+    })),
     fragments,
   }
 }
@@ -129,6 +141,19 @@ export function fromDeploymentDraft(draft: DeploymentDraft): DeploymentConfig {
     if (!isEveryDay(draft.days)) {
       deployment.time.days = WEEKDAYS.filter((day) => draft.days.includes(day))
     }
+  }
+
+  // Outside the time block: a freeze overrides the window rather than being
+  // part of it, and an entry with no window can still be frozen.
+  const freezes = draft.freezes
+    .filter((freeze) => freeze.from.trim() || freeze.to.trim())
+    .map((freeze) => ({
+      from: freeze.from.trim(),
+      to: freeze.to.trim(),
+      ...(freeze.reason?.trim() ? { reason: freeze.reason.trim() } : {}),
+    }))
+  if (freezes.length > 0) {
+    deployment.freezes = freezes
   }
 
   for (const [domainKey, fragment] of Object.entries(draft.fragments)) {
@@ -178,6 +203,23 @@ export function validateDeploymentDraft(
   if (draft.notesOnly && !draft.notes.trim()) {
     errors.notes = Methods.i18n('l10nNotesRequired')
   }
+
+  draft.freezes.forEach((freeze, index) => {
+    const from = freeze.from.trim()
+    const to = freeze.to.trim()
+    if (!from && !to && !freeze.reason?.trim()) {
+      // An untouched row is not a mistake, it is a row nobody filled in.
+      return
+    }
+    if (!isCalendarDate(from)) {
+      errors[`freeze.${index}.from`] = Methods.i18n('l10nInvalidDate')
+    }
+    if (!isCalendarDate(to)) {
+      errors[`freeze.${index}.to`] = Methods.i18n('l10nInvalidDate')
+    } else if (isCalendarDate(from) && to < from) {
+      errors[`freeze.${index}.to`] = Methods.i18n('l10nFreezeBackwards')
+    }
+  })
 
   // Without a fragment for at least one site there is no URL this entry could
   // ever match, so it would save cleanly and then silently do nothing.

--- a/tests/dashboardCards.test.tsx
+++ b/tests/dashboardCards.test.tsx
@@ -563,3 +563,87 @@ describe('HowToUse', () => {
     ).toBeInTheDocument()
   })
 })
+
+describe('a frozen card', () => {
+  function frozenConfig(reason?: string) {
+    const config = testConfig()
+    config.deployments.daytime.time = {
+      start: '09:00',
+      end: '17:00',
+      timezone: 'America/New_York',
+    }
+    ;(config.deployments.daytime as Record<string, unknown>).freezes = [
+      { from: '2026-12-20', to: '2027-01-02', ...(reason ? { reason } : {}) },
+    ]
+    return config
+  }
+
+  function renderFrozen(reason?: string) {
+    const config = frozenConfig(reason)
+    return render(
+      <DeploymentCard
+        configKey="daytime"
+        deployment={config.deployments.daytime}
+        domainKeys={DOMAINS}
+        editing={false}
+        onEdit={vi.fn()}
+        onDuplicate={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    )
+  }
+
+  it('says frozen rather than closed', () => {
+    // The same word the notice and the popup use; a card saying "closed" for
+    // the same state would read as a different one.
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-12-23T12:00:00'))
+    renderFrozen()
+
+    expect(screen.getByText('Deployment frozen')).toBeInTheDocument()
+    expect(screen.queryByText('Deployment window closed')).toBeNull()
+    vi.useRealTimers()
+  })
+
+  it('says when it lifts', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-12-23T12:00:00'))
+    const { container } = renderFrozen()
+
+    expect(container.querySelector('.dw-countdown')?.textContent).toContain(
+      'Frozen until',
+    )
+    vi.useRealTimers()
+  })
+
+  it('gives the reason its own line, and only the reason', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-12-23T12:00:00'))
+    const { container } = renderFrozen('Christmas change freeze')
+
+    const banner = container.querySelector('.dw-frozen')
+    expect(banner?.textContent).toBe('Christmas change freeze')
+    // The pill says what and the countdown says until when; repeating either
+    // here would be the card saying one thing three times.
+    expect(banner?.textContent).not.toContain('Frozen until')
+    vi.useRealTimers()
+  })
+
+  it('shows no banner when no reason was given', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-12-23T12:00:00'))
+    const { container } = renderFrozen()
+
+    expect(container.querySelector('.dw-frozen')).toBeNull()
+    vi.useRealTimers()
+  })
+
+  it('goes back to normal once the freeze has lifted', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2027-01-03T12:00:00'))
+    renderFrozen('Christmas change freeze')
+
+    expect(screen.getByText('Deployment window open')).toBeInTheDocument()
+    vi.useRealTimers()
+  })
+})

--- a/tests/dashboardCards.test.tsx
+++ b/tests/dashboardCards.test.tsx
@@ -82,17 +82,18 @@ describe('DeploymentCard', () => {
 
     expect(screen.getByRole('heading', { name: 'Daytime project' })).toBeInTheDocument()
     expect(screen.getByText('daytime')).toBeInTheDocument()
-    expect(screen.getByText('09:00 – 17:00')).toBeInTheDocument()
-    expect(screen.getByText('Europe/London')).toBeInTheDocument()
+    // The viewer's own window leads, without naming their zone. Tests run in
+    // America/New_York against a London window.
+    expect(screen.getByText('04:00 – 12:00')).toBeInTheDocument()
+    expect(screen.queryByText('America/New_York')).toBeNull()
   })
 
-  it('also shows the window in the viewer timezone', () => {
+  it('shows what the config actually says, as provenance', () => {
     atMidday()
     renderDeployment('daytime')
 
-    expect(screen.getByText('Your timezone')).toBeInTheDocument()
-    expect(screen.getByText('04:00 – 12:00')).toBeInTheDocument()
-    expect(screen.getByText('America/New_York')).toBeInTheDocument()
+    expect(screen.getByText(/Set in Europe\/London/)).toBeInTheDocument()
+    expect(screen.getByText('09:00 – 17:00')).toBeInTheDocument()
   })
 
   it('shows the window once when it is already in the viewer timezone', () => {

--- a/tests/devHarness.test.ts
+++ b/tests/devHarness.test.ts
@@ -64,6 +64,7 @@ describe('dev harness', () => {
         end: '17:00',
         timezone: 'Asia/Tokyo',
         days: [],
+        freeze: null,
       })
       // Tests are pinned to America/New_York, so the local window must differ.
       expect(info?.timeObj.local.timezone).toBe('America/New_York')

--- a/tests/dw.test.ts
+++ b/tests/dw.test.ts
@@ -129,6 +129,7 @@ describe('DW', () => {
         timezone: 'Europe/London',
         // No days configured, which means every day.
         days: [],
+        freeze: null,
       })
       expect(times.local.timezone).toBe(Timezones.findLocalTimezone())
       expect(times.local.start).toMatch(/^\d{2}:\d{2}$/)
@@ -314,5 +315,100 @@ describe('DW with days', () => {
 
     expect(info.timeObj.original.days).toEqual([])
     expect(info.canDeploy).toBe(true)
+  })
+})
+
+describe('DW with freezes', () => {
+  function frozen(freezes: unknown) {
+    const config = testConfig()
+    config.deployments.daytime.time = {
+      start: '09:00',
+      end: '17:00',
+      timezone: 'America/New_York',
+    }
+    ;(config.deployments.daytime as Record<string, unknown>).freezes = freezes
+    return config
+  }
+
+  function resolve(config: ReturnType<typeof testConfig>) {
+    return new DW(config, 'https://github.com/acme/daytime').getDeploymentInfo()!
+  }
+
+  const CHRISTMAS = [
+    { from: '2026-12-20', to: '2027-01-02', reason: 'Christmas change freeze' },
+  ]
+
+  it('shuts an otherwise open window', () => {
+    // Midday on a weekday, inside the hours: open on every other measure.
+    vi.setSystemTime(new Date('2026-12-23T12:00:00'))
+    const info = resolve(frozen(CHRISTMAS))
+
+    expect(info.canDeploy).toBe(false)
+    expect(info.status).toBe('Deployment frozen')
+  })
+
+  it('says when it lifts rather than when the window next opens', () => {
+    vi.setSystemTime(new Date('2026-12-23T12:00:00'))
+    const info = resolve(frozen(CHRISTMAS))
+
+    // "Opens in 21h" would be true of the window and false of the day.
+    const text = DW.countdownText(info.timeObj.local)
+    expect(text).toContain('Frozen until')
+    // The date is written the viewer's way round - "3 Jan" or "Jan 3" - so
+    // this asserts the day it lifts, not one locale's way of spelling it.
+    expect(text).toContain('Jan')
+    expect(text).toContain('3')
+  })
+
+  it('carries the reason through to be shown', () => {
+    vi.setSystemTime(new Date('2026-12-23T12:00:00'))
+    expect(resolve(frozen(CHRISTMAS)).timeObj.original.freeze?.reason).toBe(
+      'Christmas change freeze',
+    )
+  })
+
+  it('is over on the day after the last frozen day', () => {
+    vi.setSystemTime(new Date('2027-01-03T12:00:00'))
+    const info = resolve(frozen(CHRISTMAS))
+
+    expect(info.timeObj.original.freeze).toBeNull()
+    expect(info.canDeploy).toBe(true)
+  })
+
+  it('is already on for the whole of its first day', () => {
+    vi.setSystemTime(new Date('2026-12-20T09:30:00'))
+    expect(resolve(frozen(CHRISTMAS)).canDeploy).toBe(false)
+  })
+
+  it('leaves an entry with no freezes alone', () => {
+    vi.setSystemTime(new Date('2026-12-23T12:00:00'))
+    const info = resolve(testConfig())
+
+    expect(info.timeObj.original.freeze).toBeNull()
+    expect(info.canDeploy).toBe(true)
+  })
+
+  it('ignores a range that ends before it starts', () => {
+    vi.setSystemTime(new Date('2026-12-23T12:00:00'))
+    const info = resolve(
+      frozen([{ from: '2027-01-02', to: '2026-12-20' }]),
+    )
+
+    // Nothing can fall inside it, so it must not quietly freeze anything.
+    expect(info.canDeploy).toBe(true)
+  })
+
+  it('beats the days as well as the hours', () => {
+    vi.setSystemTime(new Date('2026-12-23T12:00:00'))
+    const config = frozen(CHRISTMAS)
+    config.deployments.daytime.time = {
+      start: '09:00',
+      end: '17:00',
+      timezone: 'America/New_York',
+      days: ['mon', 'tue', 'wed', 'thu', 'fri'],
+    }
+
+    // 23 December 2026 is a Wednesday, so the window would otherwise be open.
+    expect(resolve(config).canDeploy).toBe(false)
   })
 })

--- a/tests/forms.test.tsx
+++ b/tests/forms.test.tsx
@@ -508,3 +508,117 @@ describe('DeploymentForm days', () => {
     expect(props.onSubmit).not.toHaveBeenCalled()
   })
 })
+
+describe('DeploymentForm freezes', () => {
+  function filled(overrides = {}) {
+    const base = emptyDeploymentDraft(DOMAINS)
+    return {
+      ...base,
+      name: 'Checkout',
+      key: 'checkout',
+      fragments: { ...base.fragments, github: 'acme/checkout' },
+      ...overrides,
+    }
+  }
+
+  it('starts with none, since most entries never freeze', () => {
+    renderDeploymentForm()
+    expect(screen.queryByLabelText(/^From/)).toBeNull()
+  })
+
+  it('adds a row to fill in', async () => {
+    const user = userEvent.setup()
+    renderDeploymentForm()
+
+    await user.click(screen.getByRole('button', { name: /Add freeze/ }))
+
+    expect(screen.getByLabelText(/^From/)).toBeInTheDocument()
+    expect(screen.getByLabelText(/^To/)).toBeInTheDocument()
+    expect(screen.getByLabelText(/^Reason/)).toBeInTheDocument()
+  })
+
+  it('saves a freeze outside the time block', async () => {
+    const user = userEvent.setup()
+    const props = renderDeploymentForm({ initial: filled() })
+
+    await user.click(screen.getByRole('button', { name: /Add freeze/ }))
+    await user.type(screen.getByLabelText(/^From/), '2026-12-20')
+    await user.type(screen.getByLabelText(/^To/), '2027-01-02')
+    await user.type(screen.getByLabelText(/^Reason/), 'Christmas')
+    await user.click(screen.getByRole('button', { name: 'Save' }))
+
+    // A freeze overrides the window rather than being part of it.
+    expect(props.onSubmit).toHaveBeenCalledWith(
+      'checkout',
+      expect.objectContaining({
+        freezes: [
+          { from: '2026-12-20', to: '2027-01-02', reason: 'Christmas' },
+        ],
+      }),
+    )
+  })
+
+  it('leaves the reason off when it was not given', async () => {
+    const user = userEvent.setup()
+    const props = renderDeploymentForm({
+      initial: filled({
+        freezes: [{ from: '2026-12-24', to: '2026-12-26', reason: '' }],
+      }),
+    })
+
+    await user.click(screen.getByRole('button', { name: 'Save' }))
+
+    expect(props.onSubmit).toHaveBeenCalledWith(
+      'checkout',
+      expect.objectContaining({
+        freezes: [{ from: '2026-12-24', to: '2026-12-26' }],
+      }),
+    )
+  })
+
+  it('refuses a date it cannot read', async () => {
+    const user = userEvent.setup()
+    const props = renderDeploymentForm({
+      initial: filled({
+        freezes: [{ from: 'christmas', to: '2027-01-02', reason: '' }],
+      }),
+    })
+
+    await user.click(screen.getByRole('button', { name: 'Save' }))
+
+    expect(
+      screen.getByText('Use a real date, as YYYY-MM-DD.'),
+    ).toBeInTheDocument()
+    expect(props.onSubmit).not.toHaveBeenCalled()
+  })
+
+  it('refuses a range that ends before it starts', async () => {
+    const user = userEvent.setup()
+    const props = renderDeploymentForm({
+      initial: filled({
+        freezes: [{ from: '2027-01-02', to: '2026-12-20', reason: '' }],
+      }),
+    })
+
+    await user.click(screen.getByRole('button', { name: 'Save' }))
+
+    expect(
+      screen.getByText('The last day cannot be before the first.'),
+    ).toBeInTheDocument()
+    expect(props.onSubmit).not.toHaveBeenCalled()
+  })
+
+  it('ignores a row nobody filled in', async () => {
+    const user = userEvent.setup()
+    const props = renderDeploymentForm({ initial: filled() })
+
+    await user.click(screen.getByRole('button', { name: /Add freeze/ }))
+    await user.click(screen.getByRole('button', { name: 'Save' }))
+
+    // An empty row is a row nobody filled in, not a mistake to shout about.
+    expect(props.onSubmit).toHaveBeenCalledWith(
+      'checkout',
+      expect.not.objectContaining({ freezes: expect.anything() }),
+    )
+  })
+})

--- a/tests/freezes.test.ts
+++ b/tests/freezes.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  activeFreeze,
+  dayAfter,
+  isCalendarDate,
+  toFreezes,
+  todayIn,
+} from '../src/app/components/freezes'
+
+const CHRISTMAS = { from: '2026-12-20', to: '2027-01-02', reason: 'Change freeze' }
+
+describe('freezes', () => {
+  describe('isCalendarDate', () => {
+    it.each(['2026-12-20', '2027-01-02', '2024-02-29'])('accepts %s', (date) => {
+      expect(isCalendarDate(date)).toBe(true)
+    })
+
+    it('rejects a date that looks right and is not a day', () => {
+      // Matches the pattern, never happens.
+      expect(isCalendarDate('2026-02-30')).toBe(false)
+      expect(isCalendarDate('2025-02-29')).toBe(false)
+      expect(isCalendarDate('2026-13-01')).toBe(false)
+    })
+
+    it.each(['20-12-2026', '2026/12/20', '2026-1-1', '', null, 20261220])(
+      'rejects %j',
+      (value) => {
+        expect(isCalendarDate(value)).toBe(false)
+      },
+    )
+  })
+
+  describe('dayAfter', () => {
+    it('steps to the next day', () => {
+      expect(dayAfter('2026-12-20')).toBe('2026-12-21')
+    })
+
+    it('rolls over the end of a month', () => {
+      expect(dayAfter('2026-11-30')).toBe('2026-12-01')
+    })
+
+    it('rolls over the end of a year', () => {
+      expect(dayAfter('2026-12-31')).toBe('2027-01-01')
+    })
+
+    it('handles a leap day', () => {
+      expect(dayAfter('2024-02-28')).toBe('2024-02-29')
+      expect(dayAfter('2024-02-29')).toBe('2024-03-01')
+    })
+  })
+
+  describe('toFreezes', () => {
+    it('keeps a usable range', () => {
+      expect(toFreezes([CHRISTMAS])).toEqual([CHRISTMAS])
+    })
+
+    it('keeps a single day', () => {
+      expect(toFreezes([{ from: '2026-12-25', to: '2026-12-25' }])).toEqual([
+        { from: '2026-12-25', to: '2026-12-25' },
+      ])
+    })
+
+    it('drops a range that ends before it starts', () => {
+      // Nothing could ever fall inside it, so it is a mistake rather than a
+      // rule, and acting on it would freeze nothing while looking like it did.
+      expect(toFreezes([{ from: '2027-01-02', to: '2026-12-20' }])).toEqual([])
+    })
+
+    it.each([
+      [[{ from: '2026-12-20' }]],
+      [[{ from: 'soon', to: '2027-01-02' }]],
+      [[{ from: '2026-02-30', to: '2026-03-05' }]],
+      [[null]],
+      [['2026-12-20']],
+      ['nope'],
+      [undefined],
+    ])('drops %j', (value) => {
+      expect(toFreezes(value)).toEqual([])
+    })
+
+    it('drops a blank reason rather than storing an empty one', () => {
+      expect(
+        toFreezes([{ from: '2026-12-20', to: '2026-12-21', reason: '   ' }]),
+      ).toEqual([{ from: '2026-12-20', to: '2026-12-21' }])
+    })
+  })
+
+  describe('todayIn', () => {
+    it('reads the date in the given zone', () => {
+      // 14:00 UTC is the same day everywhere that matters here.
+      const at = new Date('2026-12-20T14:00:00Z')
+      expect(todayIn('Europe/London', at)).toBe('2026-12-20')
+      expect(todayIn('Asia/Tokyo', at)).toBe('2026-12-20')
+    })
+
+    it('is a different day either side of the date line', () => {
+      // 22:00 UTC is already tomorrow in Tokyo and still today in London.
+      const at = new Date('2026-12-20T22:00:00Z')
+      expect(todayIn('Europe/London', at)).toBe('2026-12-20')
+      expect(todayIn('Asia/Tokyo', at)).toBe('2026-12-21')
+    })
+
+    it('falls back rather than throwing on a zone it does not know', () => {
+      expect(todayIn('Mars/Olympus', new Date('2026-12-20T14:00:00Z'))).toMatch(
+        /^\d{4}-\d{2}-\d{2}$/,
+      )
+    })
+  })
+
+  describe('activeFreeze', () => {
+    it('finds a freeze covering today', () => {
+      expect(activeFreeze([CHRISTMAS], '2026-12-25')).toEqual({
+        until: '2027-01-03',
+        to: '2027-01-02',
+        reason: 'Change freeze',
+      })
+    })
+
+    it('includes both ends of the range', () => {
+      expect(activeFreeze([CHRISTMAS], '2026-12-20')).not.toBeNull()
+      expect(activeFreeze([CHRISTMAS], '2027-01-02')).not.toBeNull()
+    })
+
+    it('is over the day after it ends', () => {
+      expect(activeFreeze([CHRISTMAS], '2027-01-03')).toBeNull()
+    })
+
+    it('has not started the day before it begins', () => {
+      expect(activeFreeze([CHRISTMAS], '2026-12-19')).toBeNull()
+    })
+
+    it('reports the later end when two freezes overlap', () => {
+      // Otherwise "deploys resume on the 22nd" while the longer one runs on.
+      const freezes = [
+        { from: '2026-12-20', to: '2026-12-21' },
+        { from: '2026-12-21', to: '2026-12-30' },
+      ]
+      expect(activeFreeze(freezes, '2026-12-21')?.to).toBe('2026-12-30')
+    })
+
+    it('has an empty reason rather than none at all', () => {
+      expect(
+        activeFreeze([{ from: '2026-12-20', to: '2026-12-21' }], '2026-12-20')
+          ?.reason,
+      ).toBe('')
+    })
+
+    it('finds nothing in an empty list', () => {
+      expect(activeFreeze([], '2026-12-25')).toBeNull()
+    })
+  })
+})

--- a/tests/notice.test.ts
+++ b/tests/notice.test.ts
@@ -815,4 +815,82 @@ describe('Notice', () => {
       expect(dismissButton(inside(notice.build()))).toBeTruthy()
     })
   })
+
+  describe('a freeze', () => {
+    function frozen(reason?: string) {
+      const config = testConfig()
+      config.deployments.daytime.time = {
+        start: '09:00',
+        end: '17:00',
+        timezone: 'America/New_York',
+      }
+      ;(config.deployments.daytime as Record<string, unknown>).freezes = [
+        { from: '2026-12-20', to: '2027-01-02', ...(reason ? { reason } : {}) },
+      ]
+      const info = new DW(config, DAYTIME).getDeploymentInfo()
+      if (!info) {
+        throw new Error('no deployment resolved')
+      }
+      return info
+    }
+
+    it('says frozen, and says until when', () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2026-12-23T12:00:00'))
+
+      notice = new Notice(frozen('Christmas change freeze'))
+      const root = inside(notice.build())
+
+      expect(root.querySelector('.status-text')?.textContent).toBe(
+        'Deployment frozen',
+      )
+      expect(root.querySelector('.countdown')?.textContent).toContain(
+        'Frozen until',
+      )
+      vi.useRealTimers()
+    })
+
+    it('gives the reason a line of its own, and nothing else', () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2026-12-23T12:00:00'))
+
+      notice = new Notice(frozen('Christmas change freeze'))
+      const root = inside(notice.build())
+
+      expect(root.querySelector('.frozen')?.textContent?.trim()).toBe(
+        'Christmas change freeze',
+      )
+      vi.useRealTimers()
+    })
+
+    it('stays red rather than inventing a fourth colour', () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2026-12-23T12:00:00'))
+
+      notice = new Notice(frozen())
+      const root = inside(notice.build())
+
+      // Red already means "not today"; the reason line says which kind.
+      expect(root.querySelector('.notice')).toHaveAttribute(
+        'data-status',
+        'closed',
+      )
+      expect(root.querySelector('.frozen')).toBeNull()
+      vi.useRealTimers()
+    })
+
+    it('leaves the window alone once it has lifted', () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2027-01-03T12:00:00'))
+
+      notice = new Notice(frozen('Christmas change freeze'))
+      const root = inside(notice.build())
+
+      expect(root.querySelector('.frozen')).toBeNull()
+      expect(root.querySelector('.status-text')?.textContent).toBe(
+        'Deployment window open',
+      )
+      vi.useRealTimers()
+    })
+  })
 })

--- a/tests/notice.test.ts
+++ b/tests/notice.test.ts
@@ -75,10 +75,14 @@ describe('Notice', () => {
       const rows = [...root.querySelectorAll('.row')].map(
         (row) => row.textContent?.replace(/\s+/g, ' ').trim(),
       )
-      expect(rows[0]).toContain('09:00 – 17:00')
-      expect(rows[0]).toContain('Europe/London')
-      expect(rows[1]).toContain('04:00 – 12:00')
-      expect(rows[1]).toContain('America/New_York')
+      // Your own window leads, and does not name your zone - you know where
+      // you are. Tests run in America/New_York against a London window.
+      expect(rows[0]).toContain('Deployment window')
+      expect(rows[0]).toContain('04:00 – 12:00')
+      expect(rows[0]).not.toContain('America/New_York')
+      // What the config actually says follows, named, as provenance.
+      expect(rows[1]).toContain('Set in Europe/London')
+      expect(rows[1]).toContain('09:00 – 17:00')
       expect(root.querySelector('.status-text')?.textContent).toBe(
         'Deployment window open',
       )
@@ -168,18 +172,45 @@ describe('Notice', () => {
 
       expect(rows).toHaveLength(2)
       expect(rows[0]).toContain('Deployment window')
-      expect(rows[0]).toContain('Europe/London')
+      expect(rows[0]).toContain('09:00 – 17:00')
       // The clock keeps its row; it is the one thing that is not a repeat.
       expect(rows[1]).toContain('Current time')
-      expect(root.textContent).not.toContain('Your timezone')
+      expect(root.textContent).not.toContain('Set in')
     })
 
     it('still shows both when the window is somewhere else', () => {
       notice = new Notice(resolve(DAYTIME))
       const root = inside(notice.build())
 
-      expect(root.textContent).toContain('Your timezone')
+      expect(root.textContent).toContain('Set in Europe/London')
       expect(root.querySelectorAll('.row')).toHaveLength(3)
+    })
+
+    it('names the days once when the conversion did not move them', () => {
+      // "Mon-Thu 18:00-07:00 Zurich / Mon-Thu 17:00-06:00 London" said the
+      // days twice, and that was most of what made the strip too long.
+      const deployment = resolve(DAYTIME)
+      deployment.timeObj.original.days = ['mon', 'tue', 'wed', 'thu']
+      deployment.timeObj.local.days = ['mon', 'tue', 'wed', 'thu']
+
+      notice = new Notice(deployment)
+      const root = inside(notice.build())
+
+      expect(root.querySelectorAll('.days')).toHaveLength(1)
+      expect(root.querySelector('.days')?.textContent).toBe('Mon–Thu')
+    })
+
+    it('names them twice when the conversion did move them', () => {
+      // A Tokyo Monday is a Sunday in New York, and then both are worth saying.
+      const deployment = resolve(DAYTIME)
+      deployment.timeObj.original.days = ['mon']
+      deployment.timeObj.local.days = ['sun']
+
+      notice = new Notice(deployment)
+      const root = inside(notice.build())
+
+      const days = [...root.querySelectorAll('.days')].map((d) => d.textContent)
+      expect(days).toEqual(['Sun', 'Mon'])
     })
 
     it('omits the toggle entirely when there are no notes', () => {

--- a/tests/popup.test.tsx
+++ b/tests/popup.test.tsx
@@ -28,12 +28,12 @@ describe('Popup', () => {
 
     expect(await screen.findByText('Daytime project')).toBeInTheDocument()
     expect(screen.getByText('Deployment window')).toBeInTheDocument()
-    // Tests run in America/New_York, so the configured London window is shown
-    // alongside its converted local equivalent.
-    expect(screen.getByText('09:00 – 17:00')).toBeInTheDocument()
-    expect(screen.getByText('Europe/London')).toBeInTheDocument()
+    // Tests run in America/New_York against a London window. The viewer's own
+    // window leads and does not name their zone; the config follows, named.
     expect(screen.getByText('04:00 – 12:00')).toBeInTheDocument()
-    expect(screen.getByText('America/New_York')).toBeInTheDocument()
+    expect(screen.queryByText('America/New_York')).toBeNull()
+    expect(screen.getByText(/Set in Europe\/London/)).toBeInTheDocument()
+    expect(screen.getByText('09:00 – 17:00')).toBeInTheDocument()
     expect(screen.getByText('Deployment window open')).toBeInTheDocument()
     expect(container.querySelector('.dw-popup')).toHaveAttribute(
       'data-status',
@@ -56,7 +56,7 @@ describe('Popup', () => {
 
     await screen.findByText('Daytime project')
     expect(screen.getByText('09:00 – 17:00')).toBeInTheDocument()
-    expect(screen.queryByText('Your timezone')).toBeNull()
+    expect(screen.queryByText(/Set in/)).toBeNull()
   })
 
   it('says how much longer the window has', async () => {


### PR DESCRIPTION
"Frozen 20 December to 2 January" is the other half of how teams describe when they ship, and the half that had nowhere to go. The window said 09:00–17:00 and the extension believed it, straight through Christmas.

```json
"freezes": [
  { "from": "2026-12-20", "to": "2027-01-02", "reason": "Christmas change freeze" }
]
```

## Why it is not inside `time`

A freeze is not a property of a window. A window says when deploying is allowed in the ordinary run of things; a freeze suspends that because the people who would fix it are not there. One is a rule and the other overrides it — putting the override inside the rule would have read as a third kind of opening hours.

It also means an entry with no window can still carry one.

## The decisions

**Both ends are inclusive**, so 20 December to 2 January is frozen for the whole of both days.

**Dates are read against the window's own timezone.** A freeze is written by the same people who wrote the window, against the same calendar.

**A range that ends before it starts is refused, not ignored.** It looks like a rule, it can never contain a day, and the only symptom of getting it backwards would be a freeze that silently never happened.

**A freeze beats the hours and the days both.** It is the whole answer, so nothing below it gets asked.

## Three things, said once each

The first version said "Deployment frozen" twice and "Frozen until 31 Aug" twice — the same duplication that was worth removing from the timezone rows. Now:

| | says | example |
| --- | --- | --- |
| the pill | what is happening | Deployment frozen |
| the countdown | until when | Frozen until 31 Aug |
| the line beneath | why | Christmas change freeze |

`frozen` is a fifth status tone, wearing the **closed** mark and the closed palette. A freeze is a closed window with a reason, and red already means "not today" — inventing a fourth colour would make people learn one.

The countdown reports the date the freeze **lifts**, not its last frozen day: "until the 2nd" and "through the 2nd" are a day apart in most people's reading.

The reason line only appears when there is a reason. Without one, the pill and the countdown have already said everything.

## A bug the tests found

`freezes.ts` called `dayjs().tz()` without registering the timezone plugin. It worked — because `Timezones.ts` registers it on the shared instance and happens to be imported first in the bundle. A test that imported only `freezes.ts` got the wrong day across the date line. It extends the plugins itself now.

That is the sort of thing that would have shipped, worked everywhere it was looked at, and then broken the day someone changed an import.

## Verification

Full gate green: typecheck, lint, 181 locale messages, **841 unit tests across 29 files**, manifest, bundle, payload (106.0 kB against the 128 kB budget), **36 e2e**.

Screenshotted against a real loaded extension with a freeze in force, on the notice and on the dashboard.

## Not in this

**Recurring freezes.** "Every year, 20 Dec to 2 Jan" would need a shape without a year and a range that wraps one, and explicit dates are arguably more honest anyway — freeze dates move, and re-setting them is a decision worth making rather than inheriting.

**Global freezes.** A company-wide freeze currently has to be repeated per deployment. A shared config carries it once for the team, which takes most of the sting out, but a top-level `freezes` would be better and is a separate change.
