### PR TITLE
Stop preloading chunks the extension then refuses to use

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,6 +14,20 @@ export default defineConfig({
     // bundle is small enough that minification buys very little here.
     minify: false,
     sourcemap: true,
+    /*
+     * No modulepreload links.
+     *
+     * Vite stamps `crossorigin` on them, which is right on the web and wrong
+     * on a chrome-extension:// page: Chrome treats the preload as belonging to
+     * a different world from the module fetch that follows, refuses to reuse
+     * it, and says so twice per chunk in the console. Every preloaded chunk was
+     * being fetched and thrown away.
+     *
+     * Preloading buys close to nothing here in any case. These pages load from
+     * the extension's own storage rather than over a network, and the module
+     * graph is discovered from the entry script either way.
+     */
+    modulePreload: false,
   },
 
   // crxjs needs a stable port for its HMR websocket in `pnpm dev`.


### PR DESCRIPTION
## Short answer: not a real issue, but real waste

I reproduced it and captured everything the browser reports across all three surfaces.

```
18 messages — options: 9, popup: 8, content script: 0
errors: 0   page errors: 0   failed requests: 0
```

**Every one is a `warning`.** Nothing is broken, nothing fails to load, and the injected notice produces nothing at all. The second message you may also have seen —

> The resource … was preloaded using link preload but not used within a few seconds from the window's load event

— is just the consequence of the first, so each chunk warns twice.

## What is actually happening

Vite stamps `crossorigin` on its modulepreload links. That is correct on the web and wrong on a `chrome-extension://` page: Chrome treats the preload as belonging to a different world from the module fetch that follows, refuses to reuse it, and fetches the chunk again.

So the cost is not a bug, it is waste — every preloaded chunk is fetched, refused, and fetched a second time. From the extension's own storage rather than over a network, so it is small. But it is pure loss, and it fills the console for anyone who opens DevTools on the extension.

## The fix

There is no way to ask Vite for a preload without `crossorigin`, so the links go instead — `build.modulePreload: false`.

They were buying close to nothing here in any case: these pages load from local storage rather than over a network, and the module graph is discovered from the entry script either way.

**Before**

```html
<script type="module" crossorigin src="/assets/popup.html-SBFRoztr.js"></script>
<link rel="modulepreload" crossorigin href="/assets/rolldown-runtime-DC62tzP2.js">
<link rel="modulepreload" crossorigin href="/assets/remote-kr-9btzl.js">
<link rel="modulepreload" crossorigin href="/assets/Markdown-Bz3mRbG9.js">
<link rel="modulepreload" crossorigin href="/assets/siteBranding-BIwneFOz.js">
```

**After**

```html
<script type="module" crossorigin src="/assets/popup.html-DHQLDVpo.js"></script>
```

## Verification

Re-ran the same capture against the built extension:

```
0 console messages, popup title visible in 58ms
```

Silent on all three surfaces, and no slower — measured, not assumed.

Full gate green: typecheck, lint, 171 locale messages, 782 unit tests across 28 files, manifest, bundle, payload, 36 e2e.

Branched off `main` rather than added to #61, since this is a build-config concern with nothing to do with freezes. The two can merge in either order.
