### PR TITLE
Fail an end-to-end test that leaves the console dirty

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,15 @@ page loads cleanly under the Manifest V3 content security policy — a check wor
 keeping, since MV3 forbids `unsafe-eval` and that has already broken one
 dependency here.
 
+**Every end-to-end test fails on a dirty console.** A warning, an error or an
+uncaught exception on any page the test opened fails it, whatever the
+assertions said. It is attached to the browser context rather than to
+individual pages, so nothing has to opt in — which is the point, because the
+messages this catches are the ones nobody is looking for. A build change once
+filled every extension page with preload warnings and the suite drove a real
+Chromium past them for weeks without looking. If something is genuinely
+expected, add it to `EXPECTED_CONSOLE` in `e2e/fixtures.ts` with a reason.
+
 ### Packaging a release
 
 ```text

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -22,6 +22,29 @@ const STORAGE_KEYS = {
   deployments: 'DEPLOYMENTS',
 } as const
 
+/**
+ * Console output that is expected, and why.
+ *
+ * Deliberately empty. Every entry here is a message nobody will ever look at
+ * again, so each one needs a reason that survives being read in a year - and
+ * the moment this list is easier to add to than the underlying noise is to
+ * fix, it has stopped doing its job.
+ */
+const EXPECTED_CONSOLE: { pattern: RegExp; because: string }[] = []
+
+/** Levels worth failing a test over. `log`, `info` and `debug` are not. */
+const LOUD_LEVELS = new Set(['error', 'warning'])
+
+interface CapturedMessage {
+  where: string
+  level: string
+  text: string
+}
+
+function isExpected(text: string): boolean {
+  return EXPECTED_CONSOLE.some((entry) => entry.pattern.test(text))
+}
+
 export interface ExtensionFixtures {
   context: BrowserContext
   extensionId: string
@@ -32,6 +55,8 @@ export interface ExtensionFixtures {
    * running an http test server the response is fulfilled locally.
    */
   openStubbedPage: (url: string, body: string) => Promise<Page>
+  /** Fails the test if any page it opened logged a warning or an error. */
+  consoleGuard: void
 }
 
 export const test = base.extend<ExtensionFixtures>({
@@ -59,6 +84,61 @@ export const test = base.extend<ExtensionFixtures>({
     await context.close()
     fs.rmSync(userDataDir, { recursive: true, force: true })
   },
+
+  /**
+   * Fail a test that leaves warnings or errors in the console.
+   *
+   * Attached to the context rather than to individual pages, so it covers
+   * every page a spec opens including the ones it makes itself. `auto` means
+   * no test has to remember to ask for it - which is the point, since the
+   * warnings this exists to catch are exactly the ones nobody was looking for.
+   *
+   * It was added after a build change filled every extension page with preload
+   * warnings for weeks. The suite drove a real Chromium the whole time and
+   * never once looked at what it was saying.
+   */
+  consoleGuard: [
+    async ({ context }, use) => {
+      const captured: CapturedMessage[] = []
+
+      const watch = (page: Page) => {
+        const where = () => page.url() || 'about:blank'
+        page.on('console', (message) => {
+          if (!LOUD_LEVELS.has(message.type())) {
+            return
+          }
+          const text = message.text()
+          if (!isExpected(text)) {
+            captured.push({ where: where(), level: message.type(), text })
+          }
+        })
+        page.on('pageerror', (error) => {
+          captured.push({
+            where: where(),
+            level: 'pageerror',
+            text: String(error),
+          })
+        })
+      }
+
+      context.pages().forEach(watch)
+      context.on('page', watch)
+
+      await use()
+
+      if (captured.length > 0) {
+        const lines = captured
+          .map((m) => `  [${m.level}] ${m.text}\n      on ${m.where}`)
+          .join('\n')
+        throw new Error(
+          `The console was not clean. ${String(captured.length)} message(s):\n${lines}\n\n` +
+            'Fix the cause, or add it to EXPECTED_CONSOLE in e2e/fixtures.ts ' +
+            'with a reason.',
+        )
+      }
+    },
+    { auto: true },
+  ],
 
   extensionId: async ({ context }, use) => {
     // The MV3 service worker registers on load; wait for it to learn the id.


### PR DESCRIPTION
The suite drove a real Chromium through every surface of the extension and never once looked at what it was saying. That is how a build change filled every extension page with preload warnings and went unnoticed until somebody happened to open DevTools — two messages per chunk, on every page, for weeks, with all 36 tests green throughout.

A warning, an error or an uncaught exception on any page a test opened now fails that test, whatever its own assertions said.

## Two decisions

**Attached to the browser context, not to pages.** `context.on('page')` catches pages the specs create themselves as well as the ones the fixtures hand out.

**`auto: true`**, so nothing has to remember to ask for it. Both of those matter for the same reason: the messages this exists to catch are the ones nobody is looking for, and a check you opt into is a check that is missing exactly where it is needed.

`log`, `info` and `debug` are ignored — those are things a page says on purpose. `warning` and above are things it says when something is wrong.

## The allow-list starts empty

`EXPECTED_CONSOLE` is empty and the whole suite passes that way, so the console really is clean today rather than merely quiet. Anything added later needs a reason, because an unexplained pattern in that list is a warning nobody will ever read again.

## Verified by breaking it, twice

A `console.warn` in the popup entry:

```
✘ 8 of 9 popup tests failed
  Error: The console was not clean. 1 message(s):
    [warning] a deliberately noisy warning
        on chrome-extension://…/src/ui/popup.html
```

The ninth passed — it never opens a popup page, which is the guard being precise rather than blanket.

Then the case that matters more: an async `throw` that leaves the popup rendering perfectly.

```
✘ popup › shows the window and open status for the active tab
  Error: The console was not clean. 1 message(s):
    [pageerror] Error: a background failure nobody would see
```

Every assertion in that test still passed. Without this, it ships.

## Verification

Full gate green: typecheck, lint, 182 locale messages, 843 unit tests across 29 files, manifest, bundle, payload, **36 e2e with the guard live and the allow-list empty**.
