### PR TITLE
Ask the server what changed, and offer a way back

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,9 @@ team that deploys the same projects to the same windows. It is fetched hourly
 and merged *underneath* everything configured locally, so any single entry can
 still be corrected - or deleted - on the machine that needs it, without the
 change going anywhere near the file. Entries still tracking the file are marked
-"Shared" on the dashboard.
+"Shared" on the dashboard, and one that has been changed locally offers a
+**Revert** back to the file's version. Refreshes are conditional, so an
+unchanged config costs a round trip rather than a download.
 
 The full guide is [found here](/src/documents/HowToUse.md), and is also
 available from the "How to use" link in the options page header.

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -726,5 +726,17 @@
   "l10nConfig": {
     "message": "Config",
     "description": "Groups the shared config and JSON config panels."
+  },
+  "l10nRevertToShared": {
+    "message": "Revert",
+    "description": "Button that discards a local change and follows the shared config again."
+  },
+  "l10nRevertToSharedHint": {
+    "message": "Discard your changes and follow the shared config again",
+    "description": "Tooltip for the revert button."
+  },
+  "l10nReverted": {
+    "message": "Following the shared config again",
+    "description": "Toast after reverting a local override."
   }
 }

--- a/src/app/config/remote.ts
+++ b/src/app/config/remote.ts
@@ -38,6 +38,14 @@ export interface RemoteCache {
   config: DeploymentWindowsConfig | null
   /** Why the last attempt failed, or null when it did not. */
   error: string | null
+  /**
+   * What the server said last time, so the next fetch can ask whether anything
+   * has changed rather than asking for the whole file again.
+   */
+  etag?: string
+  lastModified?: string
+  /** True when the last refresh was answered "nothing has changed". */
+  unchanged?: boolean
 }
 
 export interface HiddenKeys {

--- a/src/app/config/remoteFetch.ts
+++ b/src/app/config/remoteFetch.ts
@@ -19,6 +19,46 @@ import type { DeploymentWindowsConfig } from './types'
  * it out.
  */
 
+/** What a server says when the conditional request was answered "no". */
+const NOT_MODIFIED = 304
+
+/**
+ * Ask the server whether anything has changed, rather than for the file.
+ *
+ * An hourly refresh that re-downloads an unchanged file all day is most of the
+ * cost of having one at all. Both validators are sent when both are known:
+ * servers vary in which they honour, and sending one the server ignores simply
+ * means the answer arrives as a 200 with the body, which is what would have
+ * happened anyway.
+ */
+function conditionalHeaders(cache: RemoteCache): Record<string, string> {
+  const headers: Record<string, string> = {}
+  if (cache.etag) {
+    headers['If-None-Match'] = cache.etag
+  }
+  if (cache.lastModified) {
+    headers['If-Modified-Since'] = cache.lastModified
+  }
+  return headers
+}
+
+/** Keep whatever the server offered for next time, and drop what it did not. */
+function rememberValidators(cache: RemoteCache, response: Response): void {
+  const etag = response.headers.get('etag')
+  const lastModified = response.headers.get('last-modified')
+
+  if (etag) {
+    cache.etag = etag
+  } else {
+    delete cache.etag
+  }
+  if (lastModified) {
+    cache.lastModified = lastModified
+  } else {
+    delete cache.lastModified
+  }
+}
+
 /** Refuse anything larger; a config this big is a wrong URL, not a config. */
 const MAX_BYTES = 512 * 1024
 
@@ -37,13 +77,18 @@ export const REFRESH_INTERVAL_MINUTES = 60
 export async function refreshRemote(): Promise<RemoteCache> {
   const url = await readRemoteUrl()
   const previous = await readCache()
-  const kept = previous?.url === url ? previous.config : null
+  const sameUrl = previous?.url === url
+  const kept = sameUrl ? previous.config : null
 
   const cache: RemoteCache = {
     url,
     fetchedAt: Date.now(),
     config: kept,
     error: null,
+    ...(sameUrl && previous.etag ? { etag: previous.etag } : {}),
+    ...(sameUrl && previous.lastModified
+      ? { lastModified: previous.lastModified }
+      : {}),
   }
 
   if (!url) {
@@ -58,7 +103,25 @@ export async function refreshRemote(): Promise<RemoteCache> {
   }
 
   try {
-    const response = await fetch(url, { cache: 'no-cache' })
+    // Only ask conditionally when there is something to fall back on. A 304
+    // with nothing cached would leave the extension holding neither the old
+    // config nor a new one.
+    const response = await fetch(url, {
+      // Our own validators do the revalidating, so the HTTP cache is left out
+      // of it entirely - otherwise a 304 arrives as an opaque 200 from cache
+      // and there is no way to tell a cheap refresh from an expensive one.
+      cache: 'no-store',
+      headers: kept ? conditionalHeaders(cache) : {},
+    })
+
+    if (response.status === NOT_MODIFIED && kept) {
+      // The file has not changed. Keep everything, including the validators,
+      // and record that this cost a round trip rather than a download.
+      cache.unchanged = true
+      await chrome.storage.local.set({ [REMOTE_CACHE_KEY]: cache })
+      return cache
+    }
+
     if (!response.ok) {
       throw new Error(`${response.status} ${response.statusText}`.trim())
     }
@@ -80,6 +143,8 @@ export async function refreshRemote(): Promise<RemoteCache> {
       sites: config.sites ?? {},
       deployments: config.deployments ?? {},
     }
+    cache.unchanged = false
+    rememberValidators(cache, response)
   } catch (error: unknown) {
     cache.error = error instanceof Error ? error.message : String(error)
   }

--- a/src/documents/HowToUse.md
+++ b/src/documents/HowToUse.md
@@ -117,10 +117,15 @@ is a layer *underneath* your own settings, which means:
 * Entries you have not touched follow the file. Change a window at the source
   and everyone picks it up on the next refresh. They are marked **Shared**.
 * Editing one stores your version on this machine, and yours wins from then on.
-  The badge goes, because that entry has stopped following the file.
+  The badge goes, because that entry has stopped following the file. **Revert**
+  on the card puts the file's version back and starts following it again.
 * Deleting one hides it here without touching the file. Add it back and it
   follows the file again.
 * Everything you add yourself is yours alone and is never sent anywhere.
+
+Refreshes are cheap. After the first fetch the extension asks the server whether
+anything has changed rather than for the file again, so an hourly refresh of an
+unchanged config costs a round trip rather than a download.
 
 If the file cannot be fetched, the last copy that worked carries on being used
 and the panel says what went wrong. Nothing is lost while it is unreachable.

--- a/src/ui/components/Options.tsx
+++ b/src/ui/components/Options.tsx
@@ -118,6 +118,49 @@ export function Options() {
     }
   }, [config, remote])
 
+  /**
+   * Entries the shared config has, which have since been changed here.
+   *
+   * The other half of the same split: `shared` is what is still following the
+   * file, this is what has stopped. Anything in neither set is simply local.
+   */
+  const overridden = useMemo(
+    () => ({
+      deployments: new Set(
+        Object.keys(remote.deployments).filter(
+          (key) => key in config.deployments && !shared.deployments.has(key),
+        ),
+      ),
+      sites: new Set(
+        Object.keys(remote.domains).filter(
+          (key) => key in config.domains && !shared.sites.has(key),
+        ),
+      ),
+    }),
+    [config, remote, shared],
+  )
+
+  /** Put the shared version back, which drops the local copy on save. */
+  const revertDeployment = (key: string) => {
+    void persist(
+      upsertDeployment(config, key, key, remote.deployments[key]),
+      Methods.i18n('l10nReverted'),
+    )
+  }
+
+  const revertSite = (key: string) => {
+    void persist(
+      upsertSite(
+        config,
+        key,
+        key,
+        remote.domains[key] ?? [],
+        remote.sites[key],
+      ),
+      Methods.i18n('l10nReverted'),
+    )
+  }
+
   const domainKeys = useMemo(() => Object.keys(config.domains), [config.domains])
   const deploymentKeys = useMemo(
     () => Object.keys(config.deployments),
@@ -354,6 +397,11 @@ export function Options() {
                   deployment={config.deployments[key]}
                   domainKeys={domainKeys}
                   shared={shared.deployments.has(key)}
+                  onRevert={
+                    overridden.deployments.has(key)
+                      ? () => revertDeployment(key)
+                      : undefined
+                  }
                   editing={editing}
                   onEdit={() => openDeployment(key)}
                   onDuplicate={() => duplicateDeployment(key)}
@@ -410,6 +458,9 @@ export function Options() {
                   site={config.sites[key]}
                   usedBy={deploymentsUsingSite(config, key)}
                   shared={shared.sites.has(key)}
+                  onRevert={
+                    overridden.sites.has(key) ? () => revertSite(key) : undefined
+                  }
                   editing={editing}
                   onEdit={() => openSite(key)}
                   onDelete={() =>

--- a/src/ui/components/common/Icons.tsx
+++ b/src/ui/components/common/Icons.tsx
@@ -122,6 +122,14 @@ export const TrashIcon = (props: IconProps) => (
   </Icon>
 )
 
+/** An arrow curving back on itself: undoing a change rather than reversing it. */
+export const UndoIcon = (props: IconProps) => (
+  <Icon {...props}>
+    <path d="M4 10h11a5 5 0 0 1 0 10h-5" />
+    <path d="m8.5 5.5-4.5 4.5 4.5 4.5" />
+  </Icon>
+)
+
 export const CopyIcon = (props: IconProps) => (
   <Icon {...props}>
     <rect x="9" y="9" width="12" height="12" rx="2" />

--- a/src/ui/components/dashboard/DeploymentCard.tsx
+++ b/src/ui/components/dashboard/DeploymentCard.tsx
@@ -6,7 +6,13 @@ import type { DeploymentConfig } from '../../../app/config/types'
 import ConfirmDelete from '../common/ConfirmDelete'
 import Countdown from '../common/Countdown'
 import StatusPill, { type StatusTone } from '../common/StatusPill'
-import { ClockIcon, CopyIcon, NoteIcon, PencilIcon } from '../common/Icons'
+import {
+  ClockIcon,
+  CopyIcon,
+  NoteIcon,
+  PencilIcon,
+  UndoIcon,
+} from '../common/Icons'
 import { useMarkdown } from '../common/useMarkdown'
 import { useNow } from '../common/useNow'
 
@@ -17,6 +23,11 @@ interface DeploymentCardProps {
   domainKeys: string[]
   /** True while this entry is still exactly what the shared config says. */
   shared?: boolean
+  /**
+   * Set when this entry came from the shared config and has been changed here.
+   * Calling it puts the shared version back.
+   */
+  onRevert?: () => void
   editing: boolean
   onEdit: () => void
   onDuplicate: () => void
@@ -74,6 +85,7 @@ export function DeploymentCard({
   onEdit,
   onDuplicate,
   onDelete,
+  onRevert,
 }: DeploymentCardProps) {
   // The status and the countdown are both worked out from the clock, so the
   // card has to keep redrawing for either to stay true.
@@ -212,6 +224,17 @@ export function DeploymentCard({
             <CopyIcon size={14} />
             {Methods.i18n('l10nDuplicate')}
           </button>
+          {onRevert && (
+            <button
+              type="button"
+              className="dw-button dw-button-ghost"
+              onClick={onRevert}
+              title={Methods.i18n('l10nRevertToSharedHint')}
+            >
+              <UndoIcon size={14} />
+              {Methods.i18n('l10nRevertToShared')}
+            </button>
+          )}
           <ConfirmDelete onConfirm={onDelete} label={name} />
         </footer>
       )}

--- a/src/ui/components/dashboard/SiteCard.tsx
+++ b/src/ui/components/dashboard/SiteCard.tsx
@@ -4,7 +4,7 @@ import { Methods } from '../../../app/components/Methods'
 import { TextFormatter } from '../../../app/components/TextFormatter'
 import type { SiteConfig } from '../../../app/config/types'
 import ConfirmDelete from '../common/ConfirmDelete'
-import { PencilIcon } from '../common/Icons'
+import { PencilIcon, UndoIcon } from '../common/Icons'
 import {
   faviconUrl,
   siteHost,
@@ -32,6 +32,8 @@ interface SiteCardProps {
   usedBy: number
   /** True while this site is still exactly what the shared config says. */
   shared?: boolean
+  /** Set when this site came from the shared config and was changed here. */
+  onRevert?: () => void
   editing: boolean
   onEdit: () => void
   onDelete: () => void
@@ -79,6 +81,7 @@ export function SiteCard({
   editing,
   onEdit,
   onDelete,
+  onRevert,
 }: SiteCardProps) {
   const host = siteHost(patterns)
   const style = site?.style
@@ -201,6 +204,17 @@ export function SiteCard({
             <PencilIcon size={14} />
             {Methods.i18n('l10nEdit')}
           </button>
+          {onRevert && (
+            <button
+              type="button"
+              className="dw-button dw-button-ghost"
+              onClick={onRevert}
+              title={Methods.i18n('l10nRevertToSharedHint')}
+            >
+              <UndoIcon size={14} />
+              {Methods.i18n('l10nRevertToShared')}
+            </button>
+          )}
           <ConfirmDelete onConfirm={onDelete} label={configKey} />
         </footer>
       )}

--- a/tests/options.test.tsx
+++ b/tests/options.test.tsx
@@ -496,6 +496,103 @@ describe('Options shared config', () => {
     expect(screen.getByRole('button', { name: 'Connect' })).toBeDisabled()
   })
 
+  it('offers no way back until something has been changed', async () => {
+    serve(shared())
+    const { user } = await openDashboard()
+    await connect(user)
+    await screen.findByRole('heading', { name: 'Team project' })
+
+    await enterEditMode(user)
+
+    // Nothing has diverged, so there is nothing to revert to.
+    expect(
+      within(cardFor('Team project')).queryByRole('button', { name: 'Revert' }),
+    ).toBeNull()
+  })
+
+  it('puts the shared version back', async () => {
+    serve(shared())
+    const { user } = await openDashboard()
+    await connect(user)
+    await screen.findByRole('heading', { name: 'Team project' })
+
+    await enterEditMode(user)
+    await user.click(
+      within(cardFor('Team project')).getByRole('button', { name: 'Edit' }),
+    )
+    const name = screen.getByLabelText(/Name/)
+    await user.clear(name)
+    await user.type(name, 'Overridden here')
+    await user.click(screen.getByRole('button', { name: 'Save' }))
+    await screen.findByRole('heading', { name: 'Overridden here' })
+
+    await user.click(
+      within(cardFor('Overridden here')).getByRole('button', {
+        name: 'Revert',
+      }),
+    )
+
+    // Back to the file's version, badged as following it again.
+    const card = await screen.findByRole('heading', { name: 'Team project' })
+    expect(within(card.closest('article')!).getByText('Shared')).toBeInTheDocument()
+  })
+
+  it('stops storing the entry once it has been reverted', async () => {
+    serve(shared())
+    const { user } = await openDashboard()
+    await connect(user)
+    await screen.findByRole('heading', { name: 'Team project' })
+
+    await enterEditMode(user)
+    await user.click(
+      within(cardFor('Team project')).getByRole('button', { name: 'Edit' }),
+    )
+    const name = screen.getByLabelText(/Name/)
+    await user.clear(name)
+    await user.type(name, 'Overridden here')
+    await user.click(screen.getByRole('button', { name: 'Save' }))
+    await screen.findByRole('heading', { name: 'Overridden here' })
+
+    // The override is stored; the seeded entries are local anyway and stay.
+    expect(
+      (await chrome.storage.sync.get('DEPLOYMENTS')).DEPLOYMENTS,
+    ).toHaveProperty('team')
+
+    await user.click(
+      within(cardFor('Overridden here')).getByRole('button', {
+        name: 'Revert',
+      }),
+    )
+    await screen.findByRole('heading', { name: 'Team project' })
+
+    // A copy left in local storage would go on shadowing the file for ever,
+    // which is the thing revert exists to undo. Everything genuinely local is
+    // untouched.
+    await waitFor(async () => {
+      const stored = (await chrome.storage.sync.get('DEPLOYMENTS'))
+        .DEPLOYMENTS as Record<string, unknown>
+      expect(stored).not.toHaveProperty('team')
+      expect(stored).toHaveProperty('daytime')
+    })
+  })
+
+  it('offers no way back for an entry that is purely local', async () => {
+    serve(shared())
+    const { user } = await openDashboard()
+    await connect(user)
+    await screen.findByRole('heading', { name: 'Team project' })
+
+    await enterEditMode(user)
+
+    // Daytime is from the seeded config, not from the file. There is nothing
+    // to revert to, and offering it would suggest there was.
+    expect(
+      within(cardFor('Daytime project')).queryByRole('button', {
+        name: 'Revert',
+      }),
+    ).toBeNull()
+  })
+
   it('survives storage being unavailable', async () => {
     const { user } = await openDashboard()
     // Reading the URL and the cache is the panel's first act; a rejection

--- a/tests/remote.test.ts
+++ b/tests/remote.test.ts
@@ -31,17 +31,51 @@ function sharedConfig(): DeploymentWindowsConfig {
   }
 }
 
+/** Every request the stubbed network saw, so the headers can be asserted. */
+let requests: { url: string; headers: Record<string, string> }[] = []
+
+/**
+ * The most recent request.
+ *
+ * Not `requests[0]`: a test that refreshes twice is usually asking about the
+ * second one, and indexing from the front quietly asserts about the first.
+ */
+function lastRequest() {
+  const request = requests[requests.length - 1]
+  if (!request) {
+    throw new Error('nothing was fetched')
+  }
+  return request
+}
+
 /** Stand in for the network, returning whatever a test wants back. */
-function serve(body: unknown, init: { ok?: boolean; status?: number } = {}) {
+function serve(
+  body: unknown,
+  init: {
+    ok?: boolean
+    status?: number
+    headers?: Record<string, string>
+  } = {},
+) {
   const text = typeof body === 'string' ? body : JSON.stringify(body)
+  const headers = init.headers ?? {}
   vi.stubGlobal(
     'fetch',
-    vi.fn(async () => ({
-      ok: init.ok ?? true,
-      status: init.status ?? 200,
-      statusText: init.status === 404 ? 'Not Found' : 'OK',
-      text: async () => text,
-    })),
+    vi.fn(async (url: string, options?: RequestInit) => {
+      requests.push({
+        url,
+        headers: (options?.headers ?? {}) as Record<string, string>,
+      })
+      return {
+        ok: init.ok ?? (init.status ?? 200) < 400,
+        status: init.status ?? 200,
+        statusText: init.status === 404 ? 'Not Found' : 'OK',
+        headers: {
+          get: (name: string) => headers[name.toLowerCase()] ?? null,
+        },
+        text: async () => text,
+      }
+    }),
   )
 }
 
@@ -51,6 +85,10 @@ async function connect(config: unknown = sharedConfig()) {
 }
 
 describe('shared config', () => {
+  beforeEach(() => {
+    requests = []
+  })
+
   afterEach(() => {
     vi.unstubAllGlobals()
   })
@@ -170,6 +208,96 @@ describe('shared config', () => {
       // The window is still the right one to show; only the copy is stale.
       expect(cache.error).toBeTruthy()
       expect(cache.config?.deployments.team.name).toBe('Team project')
+    })
+
+    it('asks for the whole file the first time', async () => {
+      serve(sharedConfig(), { headers: { etag: '"v1"' } })
+      await refreshRemote()
+
+      // Nothing to fall back on yet, so nothing conditional to ask.
+      expect(requests).toHaveLength(1)
+      expect(lastRequest().headers).toEqual({})
+    })
+
+    it('remembers the validators the server offered', async () => {
+      serve(sharedConfig(), {
+        headers: { etag: '"v1"', 'last-modified': 'Wed, 20 Aug 2026 10:00:00 GMT' },
+      })
+      const cache = await refreshRemote()
+
+      expect(cache.etag).toBe('"v1"')
+      expect(cache.lastModified).toBe('Wed, 20 Aug 2026 10:00:00 GMT')
+    })
+
+    it('asks whether anything changed on the next refresh', async () => {
+      serve(sharedConfig(), {
+        headers: { etag: '"v1"', 'last-modified': 'Wed, 20 Aug 2026 10:00:00 GMT' },
+      })
+      await refreshRemote()
+
+      serve(sharedConfig(), { headers: { etag: '"v1"' } })
+      await refreshRemote()
+
+      // An hourly refresh that re-downloads an unchanged file all day is most
+      // of the cost of having one.
+      expect(lastRequest().headers['If-None-Match']).toBe('"v1"')
+      expect(lastRequest().headers['If-Modified-Since']).toBe(
+        'Wed, 20 Aug 2026 10:00:00 GMT',
+      )
+    })
+
+    it('keeps everything when the server says nothing changed', async () => {
+      serve(sharedConfig(), { headers: { etag: '"v1"' } })
+      await refreshRemote()
+
+      serve('', { status: 304 })
+      const cache = await refreshRemote()
+
+      expect(cache.unchanged).toBe(true)
+      expect(cache.error).toBeNull()
+      expect(cache.config?.deployments.team.name).toBe('Team project')
+      // And the validator survives, so the next refresh can ask again.
+      expect(cache.etag).toBe('"v1"')
+    })
+
+    it('takes the new file when the server says it changed', async () => {
+      serve(sharedConfig(), { headers: { etag: '"v1"' } })
+      await refreshRemote()
+
+      const changed = sharedConfig()
+      changed.deployments.team.name = 'Renamed at the source'
+      serve(changed, { headers: { etag: '"v2"' } })
+      const cache = await refreshRemote()
+
+      expect(cache.unchanged).toBe(false)
+      expect(cache.config?.deployments.team.name).toBe('Renamed at the source')
+      expect(cache.etag).toBe('"v2"')
+    })
+
+    it('forgets a validator the server has stopped sending', async () => {
+      serve(sharedConfig(), { headers: { etag: '"v1"' } })
+      await refreshRemote()
+
+      serve(sharedConfig())
+      const cache = await refreshRemote()
+
+      // Otherwise it would go on asking about a version the server no longer
+      // knows, and be answered with the whole file every time anyway.
+      expect(cache.etag).toBeUndefined()
+    })
+
+    it('does not ask conditionally after the URL changes', async () => {
+      serve(sharedConfig(), { headers: { etag: '"v1"' } })
+      await refreshRemote()
+
+      await chrome.storage.sync.set({
+        [REMOTE_URL_KEY]: 'https://example.com/other.json',
+      })
+      serve(sharedConfig())
+      await refreshRemote()
+
+      // A different file's etag says nothing about this one.
+      expect(lastRequest().headers).toEqual({})
     })
 
     it('refuses a URL that is not https', async () => {


### PR DESCRIPTION
The two things the shared config was missing.

## Conditional refreshes

The hourly refresh re-downloaded the whole file every time, whether or not a byte of it had moved — which for a config that changes once a quarter is most of the cost of having a refresh at all.

It now keeps whatever validators the server offered and asks conditionally: `If-None-Match`, `If-Modified-Since`, or both when both are known. Servers differ in which they honour, and sending one that is ignored simply gets the body back — which is what would have happened anyway.

**The conditional header is only sent when there is a cached config to fall back on.** A 304 answering a request with nothing behind it would leave the extension holding neither the old config nor a new one.

`cache: 'no-store'` rather than `'no-cache'`, so the HTTP cache is out of it entirely. With the browser cache involved a 304 arrives as an opaque 200 and there is no way to tell a cheap refresh from an expensive one.

**Verified against Chrome's own network stack**, not only the test stub — the risk in this change was that fetch might not surface a real 304 at all:

```
first  -> {"status":200,"etag":"\"v1\""}
second -> {"status":304,"etag":"\"v1\""}
If-None-Match sent: ["(none)","\"v1\""]
```

## Revert

An entry from the shared config that has been changed here stops following the file — that is the point. But until now the only way back was to delete the local copy by hand and hope the shared one reappeared.

The card offers it directly, and only where there is something to go back to: **not** on an entry still matching the file, and **not** on one that was always local.

It works by writing the shared version back over the merged config. The split that decides what gets stored then sees the two are identical and stores nothing — the same rule that decides the "Shared" badge, so there is no second notion of "following the file" to keep in step with the first.

## Verification

Full gate green: typecheck, lint, 185 locale messages, **854 unit tests across 29 files**, manifest, bundle, payload, 36 e2e.

Screenshotted in dark mode with an overridden entry beside a shared one, so both states are visible at once.

**One known nit:** on an overridden card the action row is four buttons wide and wraps, leaving Delete alone on a second line. It wraps gracefully and only affects overridden entries, and the alternative — making Revert an unlabelled icon — trades clarity for a line on the rarest action here. Left as is deliberately; easy to change if you would rather.

## A test that passed for the wrong reason

`tests/remote.test.ts` asserted `requests[0]` where it meant the second request. One of the new tests caught it by failing; the one beside it had been passing on the first request's empty headers regardless of what the second sent. There is a `lastRequest()` helper now, with a comment saying why.
