### PR TITLE
Let a freeze apply to everything at once

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,9 @@ another timezone. When the next one is days away the countdown says "Opens in
 A **freeze** covers a run of calendar days when nothing ships, whatever the
 window says — a Christmas change freeze, or a conference week. While one is on
 the status reads "Deployment frozen", the countdown says when it lifts rather
-than when the window next opens, and the reason is shown beside it.
+than when the window next opens, and the reason is shown beside it. Freezes can
+be set once for everything, or per deployment; a deployment's own are added to
+the company-wide ones rather than replacing them.
 
 A **shared config** can be pointed at a JSON file on an https address, for a
 team that deploys the same projects to the same windows. It is fetched hourly

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -738,5 +738,29 @@
   "l10nReverted": {
     "message": "Following the shared config again",
     "description": "Toast after reverting a local override."
+  },
+  "l10nGlobalFreezes": {
+    "message": "Freezes",
+    "description": "Section title for company-wide freezes."
+  },
+  "l10nGlobalFreezesSubtitle": {
+    "message": "Days nothing ships, on every project at once.",
+    "description": "Subtitle for the freezes section."
+  },
+  "l10nGlobalFreezesHint": {
+    "message": "These apply to every deployment. A deployment can add its own on top.",
+    "description": "Explains what a company-wide freeze does."
+  },
+  "l10nNoFreezesYet": {
+    "message": "No freezes yet.",
+    "description": "Empty state for the freezes list."
+  },
+  "l10nEditFreezes": {
+    "message": "Edit freezes",
+    "description": "Button that opens the freeze list for editing."
+  },
+  "l10nFreezeActive": {
+    "message": "On now",
+    "description": "Badge on a freeze that covers today."
   }
 }

--- a/src/app/components/DW.ts
+++ b/src/app/components/DW.ts
@@ -10,6 +10,7 @@ import { Methods } from './Methods'
 import { Timezones, type WindowSpec, isValidTimezone } from './Timezones'
 import {
   type ActiveFreeze,
+  type Freeze,
   activeFreeze,
   toFreezes,
   todayIn,
@@ -50,6 +51,11 @@ export class DW {
 
   getUrl(): string {
     return this.currentUrl
+  }
+
+  /** Freezes that apply to every deployment in this config. */
+  globalFreezes(): Freeze[] {
+    return toFreezes(this.config.freezes)
   }
 
   /** The matched domain key (e.g. `github`), or null when nothing matched. */
@@ -132,7 +138,7 @@ export class DW {
     deployment: DeploymentConfig,
     domainKey: string,
   ): ResolvedDeployment {
-    const timeObj = DW.buildTimes(deployment)
+    const timeObj = DW.buildTimes(deployment, this.globalFreezes())
 
     return {
       key,
@@ -148,8 +154,17 @@ export class DW {
     }
   }
 
-  /** Build the original/local pair of windows for a deployment. */
-  static buildTimes(deployment: DeploymentConfig): ResolvedTimes {
+  /**
+   * Build the original/local pair of windows for a deployment.
+   *
+   * `globalFreezes` is required rather than defaulted, so that a caller which
+   * predates them cannot go on satisfying the signature while quietly leaving
+   * a company-wide freeze out of the answer.
+   */
+  static buildTimes(
+    deployment: DeploymentConfig,
+    globalFreezes: readonly Freeze[],
+  ): ResolvedTimes {
     const time = deployment.time
     const start =
       typeof time?.start === 'string' && time.start ? time.start : DEFAULT_TIME
@@ -170,8 +185,15 @@ export class DW {
     // Against the window's own calendar, not the viewer's: a freeze is written
     // by the same people who wrote the window, and 20 December means their
     // 20 December.
+    // Both sets, not one or the other: a company freeze and a project freeze
+    // are both true at once, and the longest-running of them is what decides
+    // when deploying resumes.
+    //
+    // Against this window's own timezone, as a deployment's own freezes are:
+    // a global 20 December freezes the Tokyo project by Tokyo's calendar and
+    // the London one by London's, which is what each team means by the date.
     const freeze = activeFreeze(
-      toFreezes(deployment.freezes),
+      [...globalFreezes, ...toFreezes(deployment.freezes)],
       todayIn(startTime.getOriginalTimezone()),
     )
 

--- a/src/app/config/Config.ts
+++ b/src/app/config/Config.ts
@@ -9,12 +9,14 @@ import {
   splitLocal,
   visibleRemote,
 } from './remote'
+import { toFreezes } from '../components/freezes'
 import type { DeploymentWindowsConfig, SiteConfig } from './types'
 
 export const STORAGE_KEYS = {
   domains: 'DOMAINS',
   sites: 'SITES',
   deployments: 'DEPLOYMENTS',
+  freezes: 'FREEZES',
 } as const
 
 /**
@@ -92,6 +94,7 @@ export class Config {
       STORAGE_KEYS.domains,
       STORAGE_KEYS.sites,
       STORAGE_KEYS.deployments,
+      STORAGE_KEYS.freezes,
     ])
 
     const domains = stored[STORAGE_KEYS.domains] as
@@ -104,10 +107,13 @@ export class Config {
       | DeploymentWindowsConfig['deployments']
       | undefined
 
+    const freezes = toFreezes(stored[STORAGE_KEYS.freezes])
+
     return {
       domains: domains ?? {},
       sites: migrateSites(sites ?? {}),
       deployments: deployments ?? {},
+      ...(freezes.length > 0 ? { freezes } : {}),
     }
   }
 
@@ -154,11 +160,16 @@ export class Config {
     const remote = visibleRemote(await Config.loadRemote(), await readHidden())
     // A config assembled elsewhere may be missing a section entirely; the
     // storage layer has always filled those in rather than refusing them.
+    //
+    // Every key of the config shape has to appear here. Listing three of them
+    // and forgetting the fourth is how global freezes were silently dropped on
+    // the way to storage - twice, in two different files, before a test asked.
     const { local, hidden } = splitLocal(
       {
         domains: config.domains ?? {},
         sites: config.sites ?? {},
         deployments: config.deployments ?? {},
+        ...(config.freezes ? { freezes: config.freezes } : {}),
       },
       remote,
     )
@@ -167,6 +178,7 @@ export class Config {
       [STORAGE_KEYS.domains]: local.domains,
       [STORAGE_KEYS.sites]: local.sites,
       [STORAGE_KEYS.deployments]: local.deployments,
+      [STORAGE_KEYS.freezes]: local.freezes ?? [],
     })
 
     if (isHiddenEmpty(hidden)) {
@@ -181,6 +193,7 @@ export class Config {
       STORAGE_KEYS.domains,
       STORAGE_KEYS.sites,
       STORAGE_KEYS.deployments,
+      STORAGE_KEYS.freezes,
       REMOTE_HIDDEN_KEY,
     ])
   }

--- a/src/app/config/remote.ts
+++ b/src/app/config/remote.ts
@@ -89,18 +89,33 @@ export function visibleRemote(
     domains: without(remote.domains, hidden.domains),
     sites: without(remote.sites, hidden.sites),
     deployments: without(remote.deployments, hidden.deployments),
+    // Not hideable: the freeze list is one value rather than a set of keyed
+    // entries, so there is nothing to hide individually. Replacing it locally
+    // is how you get rid of one.
+    ...(remote.freezes ? { freezes: remote.freezes } : {}),
   }
 }
 
-/** Local entries win, key by key. */
+/**
+ * Local entries win, key by key.
+ *
+ * The global freezes are the exception, because they are a list rather than a
+ * record and there is no key to win on. They are treated as one value: a local
+ * list replaces the shared one outright. Concatenating instead would read
+ * better right up until someone tried to remove a freeze the file had put
+ * there, and found they could not.
+ */
 export function mergeConfigs(
   remote: DeploymentWindowsConfig,
   local: DeploymentWindowsConfig,
 ): DeploymentWindowsConfig {
+  const freezes = local.freezes ?? remote.freezes
+
   return {
     domains: { ...remote.domains, ...local.domains },
     sites: { ...remote.sites, ...local.sites },
     deployments: { ...remote.deployments, ...local.deployments },
+    ...(freezes && freezes.length > 0 ? { freezes } : {}),
   }
 }
 
@@ -150,11 +165,18 @@ export function splitLocal(
   const sites = diffSection(merged.sites, remote.sites)
   const deployments = diffSection(merged.deployments, remote.deployments)
 
+  // One value, compared whole: identical to the shared list means it is still
+  // the shared list, and nothing needs storing.
+  const freezes = merged.freezes ?? []
+  const ownFreezes =
+    stable(freezes) === stable(remote.freezes ?? []) ? [] : freezes
+
   return {
     local: {
       domains: domains.own,
       sites: sites.own,
       deployments: deployments.own,
+      ...(ownFreezes.length > 0 ? { freezes: ownFreezes } : {}),
     },
     hidden: {
       domains: domains.missing,

--- a/src/app/config/remoteFetch.ts
+++ b/src/app/config/remoteFetch.ts
@@ -1,4 +1,5 @@
 import { validateConfig } from './schema'
+import { toFreezes } from '../components/freezes'
 import {
   REMOTE_CACHE_KEY,
   REMOTE_URL_KEY,
@@ -138,10 +139,15 @@ export async function refreshRemote(): Promise<RemoteCache> {
     }
 
     const config = parsed as DeploymentWindowsConfig
+    // Rebuilt section by section rather than kept whole, so a file with extra
+    // keys cannot smuggle them into storage. Anything added to the config
+    // shape has to be added here too - global freezes were dropped on the way
+    // in until a test asked for them back.
     cache.config = {
       domains: config.domains ?? {},
       sites: config.sites ?? {},
       deployments: config.deployments ?? {},
+      ...(config.freezes ? { freezes: toFreezes(config.freezes) } : {}),
     }
     cache.unchanged = false
     rememberValidators(cache, response)

--- a/src/app/config/schema.ts
+++ b/src/app/config/schema.ts
@@ -25,6 +25,9 @@ const INSERT_POSITIONS = ['before', 'after'] as const
 
 const TIME_KNOWN_KEYS = new Set(['start', 'end', 'timezone', 'days'])
 
+/** `freezes` is optional, so an existing config without one still validates. */
+const CONFIG_KNOWN_KEYS = new Set(['domains', 'sites', 'deployments', 'freezes'])
+
 const DEPLOYMENT_KNOWN_KEYS = new Set([
   'name',
   'notes',
@@ -375,9 +378,13 @@ export function validateConfig(value: unknown): ValidationResult {
   }
 
   for (const key of Object.keys(value)) {
-    if (key !== 'domains' && key !== 'sites' && key !== 'deployments') {
+    if (!CONFIG_KNOWN_KEYS.has(key)) {
       errors.add('', `must NOT have additional properties ('${key}')`)
     }
+  }
+
+  if ('freezes' in value) {
+    validateFreezes(value.freezes, '/freezes', errors)
   }
 
   if ('domains' in value) validateDomains(value.domains, '/domains', errors)

--- a/src/app/config/types.ts
+++ b/src/app/config/types.ts
@@ -80,6 +80,16 @@ export interface DeploymentWindowsConfig {
   sites: Record<string, SiteConfig>
   /** deployment key -> deployment */
   deployments: Record<string, DeploymentConfig>
+  /**
+   * Freezes that apply to everything.
+   *
+   * "We do not ship over Christmas" is one fact about a company, not one fact
+   * repeated on every project - and repeated facts are how a config ends up
+   * with a freeze on eight deployments and not on the ninth. A deployment's
+   * own freezes are added to these rather than replacing them: both are true
+   * at once.
+   */
+  freezes?: Freeze[]
 }
 
 export interface ResolvedTimeWindow {

--- a/src/documents/HowToUse.md
+++ b/src/documents/HowToUse.md
@@ -167,6 +167,16 @@ was written in.
 A freeze beats everything else. It does not matter what the hours say or which
 days are ticked.
 
+**Company-wide freezes** live in their own section on this page rather than on
+each project. "We do not ship over Christmas" is one fact about a company, not
+one fact repeated on every deployment — and repeated facts are how a config
+ends up frozen on eight projects and not on the ninth.
+
+A deployment's own freezes are *added* to those, not swapped for them: both are
+true at once, and whichever runs longest is the one that decides when deploying
+resumes. Put the company freeze in a [shared config](#sharing-one-config-with-a-team)
+and everyone gets it from one place.
+
 ---
 
 ## Editing the JSON directly
@@ -259,7 +269,7 @@ time.time_data.start|time[24]|24 hour time the window opens, e.g. `09:00`
 time.time_data.end|time[24]|24 hour time the window closes; may be earlier than the start to run past midnight
 time.time_data.timezone|string|An [IANA timezone](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) such as `Europe/London`
 time.time_data.days|array[day]|Days the window opens on, e.g. `["mon","tue","wed","thu","fri"]`. Leave it out for every day
-freezes|array[freeze_data]|Runs of days when nothing ships, whatever the window says
+freezes|array[freeze_data]|Runs of days when nothing ships for *this* deployment, on top of any company-wide ones
 freezes.freeze_data.from|date|First frozen day, `YYYY-MM-DD`, included
 freezes.freeze_data.to|date|Last frozen day, `YYYY-MM-DD`, included
 freezes.freeze_data.reason|string|Optional, shown wherever the freeze is reported

--- a/src/styles/options.css
+++ b/src/styles/options.css
@@ -610,6 +610,54 @@ body {
 }
 
 /* ------------------------------------------------------------------ */
+/* freezes                                                             */
+/* ------------------------------------------------------------------ */
+
+/* A list rather than cards. A freeze is three short facts, most teams have one
+   or two, and a grid of cards for that is more furniture than content. */
+.dw-freeze-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  background: var(--dw-border);
+  border: 1px solid var(--dw-border);
+  border-radius: var(--dw-radius);
+  overflow: hidden;
+}
+
+.dw-freeze {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: var(--dw-space-2) var(--dw-space-4);
+  padding: var(--dw-space-3) var(--dw-space-4);
+  background: var(--dw-surface);
+}
+
+.dw-freeze-dates {
+  font-size: 0.86rem;
+  white-space: nowrap;
+}
+
+.dw-freeze-reason {
+  color: var(--dw-text-muted);
+  font-size: 0.9rem;
+  min-width: 0;
+}
+
+/* The one that is happening now, rather than the ones that will or did. */
+.dw-freeze-on {
+  background: var(--dw-warn-soft);
+}
+
+.dw-freeze-on .dw-freeze-reason {
+  color: var(--dw-text);
+}
+
+/* ------------------------------------------------------------------ */
 /* empty states                                                        */
 /* ------------------------------------------------------------------ */
 

--- a/src/ui/components/Options.tsx
+++ b/src/ui/components/Options.tsx
@@ -1,6 +1,12 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 
 import { Methods } from '../../app/components/Methods'
+import {
+  activeFreeze,
+  toFreezes,
+  todayIn,
+} from '../../app/components/freezes'
+import { Timezones } from '../../app/components/Timezones'
 import { Config, defaultConfig } from '../../app/config/Config'
 import {
   emptyConfig,
@@ -20,6 +26,7 @@ import { PlusIcon, SearchIcon, StatusMark } from './common/Icons'
 import DashboardHeader from './dashboard/DashboardHeader'
 import DeploymentCard, { statusFor } from './dashboard/DeploymentCard'
 import DeploymentForm from './dashboard/DeploymentForm'
+import FreezeForm from './dashboard/FreezeForm'
 import JsonPanel from './dashboard/JsonPanel'
 import SiteCard from './dashboard/SiteCard'
 import SharedConfigPanel from './dashboard/SharedConfigPanel'
@@ -42,6 +49,7 @@ import { matchesFilter, uniqueKey, useTick } from './dashboard/support'
 type Dialog =
   | { kind: 'deployment'; originalKey: string | null; draft: DeploymentDraft }
   | { kind: 'site'; originalKey: string | null; draft: SiteDraft }
+  | { kind: 'freezes' }
 
 /**
  * The options page.
@@ -167,13 +175,20 @@ export function Options() {
     [config.deployments],
   )
 
+  /** Freezes that apply to everything, read from the merged config. */
+  const globalFreezes = useMemo(() => toFreezes(config.freezes), [config.freezes])
+  // The list is a summary rather than a per-project answer, so "on now" is
+  // read against the viewer's own calendar. Each deployment still decides for
+  // itself, against the timezone its window is written in.
+  const localZone = Timezones.findLocalTimezone()
+
   const openCount = useMemo(
     () =>
       Object.values(config.deployments).filter(
-        (deployment) => statusFor(deployment) === 'open',
+        (deployment) => statusFor(deployment, globalFreezes) === 'open',
       ).length,
     // Recomputed on every tick as well, since the answer changes with the clock.
-    [config.deployments, tick],
+    [config.deployments, globalFreezes, tick],
   )
 
   const visibleDeployments = deploymentKeys.filter((key) => {
@@ -396,6 +411,7 @@ export function Options() {
                   configKey={key}
                   deployment={config.deployments[key]}
                   domainKeys={domainKeys}
+                  globalFreezes={globalFreezes}
                   shared={shared.deployments.has(key)}
                   onRevert={
                     overridden.deployments.has(key)
@@ -414,6 +430,59 @@ export function Options() {
                 />
               ))}
             </div>
+          )}
+        </section>
+
+        <section className="dw-section" aria-labelledby="dw-freezes-title">
+          <div className="dw-section-head">
+            <div className="dw-section-heading">
+              <h2 className="dw-section-title" id="dw-freezes-title">
+                {Methods.i18n('l10nGlobalFreezes')}
+              </h2>
+              <p className="dw-section-subtitle">
+                {Methods.i18n('l10nGlobalFreezesSubtitle')}
+              </p>
+            </div>
+            {editing && (
+              <button
+                type="button"
+                className="dw-button dw-button-primary"
+                onClick={() => setDialog({ kind: 'freezes' })}
+              >
+                <PlusIcon size={15} />
+                {Methods.i18n('l10nEditFreezes')}
+              </button>
+            )}
+          </div>
+
+          {globalFreezes.length === 0 ? (
+            <p className="dw-empty-inline">
+              {Methods.i18n('l10nNoFreezesYet')}
+            </p>
+          ) : (
+            <ul className="dw-freeze-list">
+              {globalFreezes.map((freeze) => {
+                const on = activeFreeze([freeze], todayIn(localZone)) !== null
+                return (
+                  <li
+                    className={`dw-freeze${on ? ' dw-freeze-on' : ''}`}
+                    key={`${freeze.from}-${freeze.to}-${freeze.reason ?? ''}`}
+                  >
+                    <span className="dw-mono dw-freeze-dates">
+                      {freeze.from} &ndash; {freeze.to}
+                    </span>
+                    {freeze.reason && (
+                      <span className="dw-freeze-reason">{freeze.reason}</span>
+                    )}
+                    {on && (
+                      <span className="dw-badge dw-badge-warn">
+                        {Methods.i18n('l10nFreezeActive')}
+                      </span>
+                    )}
+                  </li>
+                )
+              })}
+            </ul>
           )}
         </section>
 
@@ -506,6 +575,23 @@ export function Options() {
           initial={dialog.draft}
           takenKeys={domainKeys.filter((key) => key !== dialog.originalKey)}
           onSubmit={saveSite}
+          onClose={() => setDialog(null)}
+        />
+      )}
+
+      {dialog?.kind === 'freezes' && (
+        <FreezeForm
+          initial={globalFreezes}
+          onSubmit={(freezes) => {
+            setDialog(null)
+            void persist(
+              {
+                ...config,
+                ...(freezes.length > 0 ? { freezes } : { freezes: [] }),
+              },
+              Methods.i18n('l10nSaved'),
+            )
+          }}
           onClose={() => setDialog(null)}
         />
       )}

--- a/src/ui/components/dashboard/DeploymentCard.tsx
+++ b/src/ui/components/dashboard/DeploymentCard.tsx
@@ -2,6 +2,7 @@ import { DW } from '../../../app/components/DW'
 import { daysLabel } from '../../../app/components/dayLabels'
 import { Methods } from '../../../app/components/Methods'
 import { TextFormatter } from '../../../app/components/TextFormatter'
+import type { Freeze } from '../../../app/components/freezes'
 import type { DeploymentConfig } from '../../../app/config/types'
 import ConfirmDelete from '../common/ConfirmDelete'
 import Countdown from '../common/Countdown'
@@ -21,6 +22,8 @@ interface DeploymentCardProps {
   deployment: DeploymentConfig
   /** Every configured site key, so missing fragments can be shown as gaps. */
   domainKeys: string[]
+  /** Freezes that apply to everything, not just to this entry. */
+  globalFreezes?: readonly Freeze[]
   /** True while this entry is still exactly what the shared config says. */
   shared?: boolean
   /**
@@ -35,7 +38,15 @@ interface DeploymentCardProps {
 }
 
 /** What the pill should say for this entry, right now. */
-export function statusFor(deployment: DeploymentConfig): StatusTone {
+/**
+ * `globalFreezes` is required rather than defaulted. Defaulting it let the
+ * "open now" count on the options page go on compiling while reporting a
+ * frozen deployment as open.
+ */
+export function statusFor(
+  deployment: DeploymentConfig,
+  globalFreezes: readonly Freeze[],
+): StatusTone {
   if (deployment['notes-only'] === true) {
     return 'notes'
   }
@@ -44,7 +55,7 @@ export function statusFor(deployment: DeploymentConfig): StatusTone {
     // the day. Saying so is more use than showing a permanent red "closed".
     return 'unset'
   }
-  const { local } = DW.buildTimes(deployment)
+  const { local } = DW.buildTimes(deployment, globalFreezes)
   if (local.freeze) {
     return 'frozen'
   }
@@ -80,6 +91,7 @@ export function DeploymentCard({
   configKey,
   deployment,
   domainKeys,
+  globalFreezes = [],
   shared = false,
   editing,
   onEdit,
@@ -90,14 +102,16 @@ export function DeploymentCard({
   // The status and the countdown are both worked out from the clock, so the
   // card has to keep redrawing for either to stay true.
   useNow()
-  const tone = statusFor(deployment)
+  const tone = statusFor(deployment, globalFreezes)
   const name =
     typeof deployment.name === 'string' && deployment.name
       ? deployment.name
       : configKey
   const notes = typeof deployment.notes === 'string' ? deployment.notes : ''
   const notesHtml = useMarkdown(notes)
-  const times = deployment.time ? DW.buildTimes(deployment) : null
+  const times = deployment.time
+    ? DW.buildTimes(deployment, globalFreezes)
+    : null
   // Your own window leads, and does not name your zone; what the config says
   // follows as provenance, and only when it differs.
   const showSource =

--- a/src/ui/components/dashboard/FreezeForm.tsx
+++ b/src/ui/components/dashboard/FreezeForm.tsx
@@ -1,0 +1,216 @@
+import { useState } from 'react'
+
+import {
+  type Freeze,
+  isCalendarDate,
+} from '../../../app/components/freezes'
+import { Methods } from '../../../app/components/Methods'
+import Field from '../common/Field'
+import { PlusIcon, TrashIcon } from '../common/Icons'
+import Modal from '../common/Modal'
+import type { DraftErrors } from './drafts'
+
+/** A freeze as typed, before it is known to be a pair of real dates. */
+export type FreezeDraft = { from: string; to: string; reason: string }
+
+export function toFreezeDrafts(freezes: readonly Freeze[]): FreezeDraft[] {
+  return freezes.map((freeze) => ({
+    from: freeze.from,
+    to: freeze.to,
+    reason: freeze.reason ?? '',
+  }))
+}
+
+/** Blank rows are dropped rather than saved; a reason is left off when empty. */
+export function fromFreezeDrafts(drafts: readonly FreezeDraft[]): Freeze[] {
+  return drafts
+    .filter((draft) => draft.from.trim() || draft.to.trim())
+    .map((draft) => ({
+      from: draft.from.trim(),
+      to: draft.to.trim(),
+      ...(draft.reason.trim() ? { reason: draft.reason.trim() } : {}),
+    }))
+}
+
+export function validateFreezeDrafts(
+  drafts: readonly FreezeDraft[],
+): DraftErrors {
+  const errors: DraftErrors = {}
+
+  drafts.forEach((draft, index) => {
+    const from = draft.from.trim()
+    const to = draft.to.trim()
+    if (!from && !to && !draft.reason.trim()) {
+      // An untouched row is a row nobody filled in, not a mistake.
+      return
+    }
+    if (!isCalendarDate(from)) {
+      errors[`freeze.${String(index)}.from`] = Methods.i18n('l10nInvalidDate')
+    }
+    if (!isCalendarDate(to)) {
+      errors[`freeze.${String(index)}.to`] = Methods.i18n('l10nInvalidDate')
+    } else if (isCalendarDate(from) && to < from) {
+      errors[`freeze.${String(index)}.to`] = Methods.i18n('l10nFreezeBackwards')
+    }
+  })
+
+  return errors
+}
+
+interface FreezeFormProps {
+  initial: readonly Freeze[]
+  onSubmit: (freezes: Freeze[]) => void
+  onClose: () => void
+}
+
+/**
+ * The whole list of company-wide freezes, edited at once.
+ *
+ * One dialog rather than a card and a form per freeze: a freeze is three
+ * fields, most teams have one or two, and a page of cards for that would be
+ * more furniture than content.
+ */
+export function FreezeForm({ initial, onSubmit, onClose }: FreezeFormProps) {
+  const [drafts, setDrafts] = useState<FreezeDraft[]>(() =>
+    toFreezeDrafts(initial),
+  )
+  const [errors, setErrors] = useState<DraftErrors>({})
+  const [submitted, setSubmitted] = useState(false)
+
+  const update = (next: FreezeDraft[]) => {
+    setDrafts(next)
+    if (submitted) {
+      setErrors(validateFreezeDrafts(next))
+    }
+  }
+
+  const setRow = (index: number, patch: Partial<FreezeDraft>) => {
+    update(
+      drafts.map((draft, position) =>
+        position === index ? { ...draft, ...patch } : draft,
+      ),
+    )
+  }
+
+  const submit = () => {
+    setSubmitted(true)
+    const found = validateFreezeDrafts(drafts)
+    setErrors(found)
+    if (Object.keys(found).length > 0) {
+      return
+    }
+    onSubmit(fromFreezeDrafts(drafts))
+  }
+
+  const shown = (field: string) => (submitted ? (errors[field] ?? null) : null)
+
+  return (
+    <Modal
+      title={Methods.i18n('l10nFreezes')}
+      description={Methods.i18n('l10nGlobalFreezesHint')}
+      onClose={onClose}
+      footer={
+        <>
+          <button
+            type="button"
+            className="dw-button dw-button-ghost"
+            onClick={onClose}
+          >
+            {Methods.i18n('l10nCancel')}
+          </button>
+          <button
+            type="button"
+            className="dw-button dw-button-primary"
+            onClick={submit}
+          >
+            {Methods.i18n('l10nSave')}
+          </button>
+        </>
+      }
+    >
+      <form
+        onSubmit={(event) => {
+          event.preventDefault()
+          submit()
+        }}
+        noValidate
+      >
+        {drafts.length === 0 && (
+          <p className="dw-empty-inline">{Methods.i18n('l10nNoFreezesYet')}</p>
+        )}
+
+        {drafts.map((draft, index) => (
+          <div className="dw-repeat-row dw-repeat-row-freeze" key={index}>
+            <Field
+              label={Methods.i18n('l10nFreezeFrom')}
+              error={shown(`freeze.${String(index)}.from`)}
+            >
+              {({ id }) => (
+                <input
+                  id={id}
+                  className="dw-input"
+                  type="date"
+                  value={draft.from}
+                  onChange={(event) =>
+                    setRow(index, { from: event.target.value })
+                  }
+                />
+              )}
+            </Field>
+            <Field
+              label={Methods.i18n('l10nFreezeTo')}
+              error={shown(`freeze.${String(index)}.to`)}
+            >
+              {({ id }) => (
+                <input
+                  id={id}
+                  className="dw-input"
+                  type="date"
+                  value={draft.to}
+                  onChange={(event) => setRow(index, { to: event.target.value })}
+                />
+              )}
+            </Field>
+            <Field label={Methods.i18n('l10nFreezeReason')}>
+              {({ id }) => (
+                <input
+                  id={id}
+                  className="dw-input"
+                  type="text"
+                  placeholder="Christmas change freeze"
+                  value={draft.reason}
+                  onChange={(event) =>
+                    setRow(index, { reason: event.target.value })
+                  }
+                />
+              )}
+            </Field>
+            <button
+              type="button"
+              className="dw-icon-button dw-icon-button-danger"
+              aria-label={`${Methods.i18n('l10nRemove')} ${Methods.i18n('l10nFreezes')} ${String(index + 1)}`}
+              onClick={() =>
+                update(drafts.filter((_, position) => position !== index))
+              }
+            >
+              <TrashIcon size={15} />
+            </button>
+          </div>
+        ))}
+
+        <button
+          type="button"
+          className="dw-button dw-button-ghost dw-button-small"
+          onClick={() =>
+            update([...drafts, { from: '', to: '', reason: '' }])
+          }
+        >
+          <PlusIcon size={14} />
+          {Methods.i18n('l10nAddFreeze')}
+        </button>
+      </form>
+    </Modal>
+  )
+}
+
+export default FreezeForm

--- a/tests/dashboardCards.test.tsx
+++ b/tests/dashboardCards.test.tsx
@@ -53,25 +53,25 @@ describe('statusFor', () => {
     // 09:00-17:00 Europe/London is 04:00-12:00 in New York.
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2024-06-03T10:00:00'))
-    expect(statusFor(testConfig().deployments.daytime)).toBe('open')
+    expect(statusFor(testConfig().deployments.daytime, [])).toBe('open')
   })
 
   it('reports closed outside it', () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2024-06-03T18:00:00'))
-    expect(statusFor(testConfig().deployments.daytime)).toBe('closed')
+    expect(statusFor(testConfig().deployments.daytime, [])).toBe('closed')
   })
 
   it('reports notes for a notes-only entry, whatever the time', () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2024-06-03T18:00:00'))
-    expect(statusFor(testConfig().deployments.notesOnly)).toBe('notes')
+    expect(statusFor(testConfig().deployments.notesOnly, [])).toBe('notes')
   })
 
   it('flags an entry with no window rather than calling it closed', () => {
     // Without times it resolves to 00:00-00:00, so a plain red "closed" would
     // be technically true and completely unhelpful.
-    expect(statusFor(testConfig().deployments.untimed)).toBe('unset')
+    expect(statusFor(testConfig().deployments.untimed, [])).toBe('unset')
   })
 })
 

--- a/tests/dw.test.ts
+++ b/tests/dw.test.ts
@@ -412,3 +412,85 @@ describe('DW with freezes', () => {
     expect(resolve(config).canDeploy).toBe(false)
   })
 })
+
+describe('DW with global freezes', () => {
+  function withFreezes(
+    global?: unknown,
+    own?: unknown,
+  ): ReturnType<typeof testConfig> {
+    const config = testConfig()
+    config.deployments.daytime.time = {
+      start: '09:00',
+      end: '17:00',
+      timezone: 'America/New_York',
+    }
+    if (global) {
+      config.freezes = global as ReturnType<typeof testConfig>['freezes']
+    }
+    if (own) {
+      ;(config.deployments.daytime as Record<string, unknown>).freezes = own
+    }
+    return config
+  }
+
+  function resolve(config: ReturnType<typeof testConfig>) {
+    return new DW(config, 'https://github.com/acme/daytime').getDeploymentInfo()!
+  }
+
+  const CHRISTMAS = [{ from: '2026-12-20', to: '2027-01-02', reason: 'Company freeze' }]
+
+  it('shuts every deployment, not just the ones that asked', () => {
+    vi.setSystemTime(new Date('2026-12-23T12:00:00'))
+    const info = resolve(withFreezes(CHRISTMAS))
+
+    expect(info.canDeploy).toBe(false)
+    expect(info.status).toBe('Deployment frozen')
+    expect(info.timeObj.original.freeze?.reason).toBe('Company freeze')
+  })
+
+  it('leaves everything alone outside the dates', () => {
+    vi.setSystemTime(new Date('2027-01-03T12:00:00'))
+    expect(resolve(withFreezes(CHRISTMAS)).canDeploy).toBe(true)
+  })
+
+  it('adds to a deployment freeze rather than replacing it', () => {
+    // A company freeze and a project freeze are both true at once.
+    vi.setSystemTime(new Date('2026-06-10T12:00:00'))
+    const info = resolve(
+      withFreezes(CHRISTMAS, [
+        { from: '2026-06-08', to: '2026-06-12', reason: 'Migration' },
+      ]),
+    )
+
+    expect(info.canDeploy).toBe(false)
+    expect(info.timeObj.original.freeze?.reason).toBe('Migration')
+  })
+
+  it('reports whichever of the two runs longest', () => {
+    // Otherwise "deploys resume on the 24th" while the company freeze runs on.
+    vi.setSystemTime(new Date('2026-12-23T12:00:00'))
+    const info = resolve(
+      withFreezes(CHRISTMAS, [
+        { from: '2026-12-22', to: '2026-12-23', reason: 'Migration' },
+      ]),
+    )
+
+    expect(info.timeObj.original.freeze?.to).toBe('2027-01-02')
+    expect(info.timeObj.original.freeze?.reason).toBe('Company freeze')
+  })
+
+  it('ignores a global freeze it cannot read', () => {
+    vi.setSystemTime(new Date('2026-12-23T12:00:00'))
+    expect(resolve(withFreezes([{ from: 'christmas', to: 'new year' }])).canDeploy).toBe(
+      true,
+    )
+  })
+
+  it('leaves a config with no global freezes exactly as it was', () => {
+    vi.setSystemTime(new Date('2026-12-23T12:00:00'))
+    const info = resolve(testConfig())
+
+    expect(info.timeObj.original.freeze).toBeNull()
+    expect(info.canDeploy).toBe(true)
+  })
+})

--- a/tests/options.test.tsx
+++ b/tests/options.test.tsx
@@ -626,3 +626,84 @@ describe('Options shared config', () => {
     expect(screen.getByRole('heading', { name: 'Daytime project' })).toBeInTheDocument()
   })
 })
+
+describe('Options global freezes', () => {
+  it('says there are none, rather than showing an empty list', async () => {
+    await openDashboard()
+    expect(screen.getByText('No freezes yet.')).toBeInTheDocument()
+  })
+
+  it('adds one that applies to everything', async () => {
+    const { user } = await openDashboard()
+    await enterEditMode(user)
+
+    await user.click(screen.getByRole('button', { name: /Edit freezes/ }))
+    await user.click(screen.getByRole('button', { name: /Add freeze/ }))
+    await user.type(screen.getByLabelText(/^From/), '2026-12-20')
+    await user.type(screen.getByLabelText(/^To/), '2027-01-02')
+    await user.type(screen.getByLabelText(/^Reason/), 'Company freeze')
+    await user.click(screen.getByRole('button', { name: 'Save' }))
+
+    expect(await screen.findByText('Company freeze')).toBeInTheDocument()
+    expect(
+      (await chrome.storage.sync.get('FREEZES')).FREEZES,
+    ).toEqual([
+      { from: '2026-12-20', to: '2027-01-02', reason: 'Company freeze' },
+    ])
+  })
+
+  it('freezes every deployment while it is on', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    vi.setSystemTime(new Date('2026-12-23T12:00:00'))
+
+    const config = testConfig()
+    config.freezes = [{ from: '2026-12-20', to: '2027-01-02' }]
+    await openDashboard(config)
+
+    // Every entry with a window, not just one that asked to be frozen.
+    const frozen = screen.getAllByText('Deployment frozen')
+    expect(frozen.length).toBeGreaterThan(1)
+    vi.useRealTimers()
+  })
+
+  it('marks the one that is running now', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    vi.setSystemTime(new Date('2026-12-23T12:00:00'))
+
+    const config = testConfig()
+    // Distinctive, because the reason also appears on every frozen card.
+    config.freezes = [
+      { from: '2026-12-20', to: '2027-01-02', reason: 'Running right now' },
+      { from: '2027-06-01', to: '2027-06-07', reason: 'Some way off' },
+    ]
+    await openDashboard(config)
+
+    const now = screen
+      .getAllByText('Running right now')
+      .map((node) => node.closest('li'))
+      .find(Boolean)
+    const later = screen.getByText('Some way off').closest('li')
+    expect(within(now!).getByText('On now')).toBeInTheDocument()
+    expect(within(later!).queryByText('On now')).toBeNull()
+    vi.useRealTimers()
+  })
+
+  it('refuses a range that ends before it starts', async () => {
+    // Typed rather than seeded: a stored range that can never contain a day is
+    // dropped when the config loads, so there would be nothing left to refuse.
+    const { user } = await openDashboard()
+    await enterEditMode(user)
+
+    await user.click(screen.getByRole('button', { name: /Edit freezes/ }))
+    await user.click(screen.getByRole('button', { name: /Add freeze/ }))
+    await user.type(screen.getByLabelText(/^From/), '2027-01-02')
+    await user.type(screen.getByLabelText(/^To/), '2026-12-20')
+    await user.click(screen.getByRole('button', { name: 'Save' }))
+
+    expect(
+      screen.getByText('The last day cannot be before the first.'),
+    ).toBeInTheDocument()
+    // The seeding save wrote an empty list; the refused one did not add to it.
+    expect((await chrome.storage.sync.get('FREEZES')).FREEZES).toEqual([])
+  })
+})

--- a/tests/remote.test.ts
+++ b/tests/remote.test.ts
@@ -372,6 +372,49 @@ describe('shared config', () => {
       ).toBeUndefined()
     })
 
+    it('takes global freezes from the shared config', async () => {
+      // The point of a company freeze in a shared file: one entry, everyone.
+      serve({
+        ...sharedConfig(),
+        freezes: [{ from: '2026-12-20', to: '2027-01-02', reason: 'Company' }],
+      })
+      await setRemoteUrl(URL_)
+
+      expect((await Config.load()).freezes).toEqual([
+        { from: '2026-12-20', to: '2027-01-02', reason: 'Company' },
+      ])
+    })
+
+    it('does not store a shared freeze list as if it were yours', async () => {
+      serve({
+        ...sharedConfig(),
+        freezes: [{ from: '2026-12-20', to: '2027-01-02' }],
+      })
+      await setRemoteUrl(URL_)
+      await Config.save(await Config.load())
+
+      expect((await chrome.storage.sync.get('FREEZES')).FREEZES).toEqual([])
+    })
+
+    it('lets a local list replace the shared one', async () => {
+      serve({
+        ...sharedConfig(),
+        freezes: [{ from: '2026-12-20', to: '2027-01-02' }],
+      })
+      await setRemoteUrl(URL_)
+
+      const merged = await Config.load()
+      merged.freezes = [{ from: '2026-07-01', to: '2026-07-14', reason: 'Ours' }]
+      await Config.save(merged)
+
+      // A list, not a record: there is no key to win on, so it is one value.
+      // Concatenating would read better until someone tried to remove a freeze
+      // the file had put there and found they could not.
+      expect((await Config.load()).freezes).toEqual([
+        { from: '2026-07-01', to: '2026-07-14', reason: 'Ours' },
+      ])
+    })
+
     it('does not fall back to the defaults when only the shared layer has entries', async () => {
       await connect()
 


### PR DESCRIPTION
"We do not ship over Christmas" is one fact about a company, not one fact repeated on every project — and repeated facts are how a config ends up frozen on eight deployments and not on the ninth.

```json
{
  "domains": { … },
  "sites": { … },
  "deployments": { … },
  "freezes": [
    { "from": "2026-12-20", "to": "2027-01-02", "reason": "Christmas change freeze" }
  ]
}
```

Optional, so every existing config is untouched. There is a **Freezes** section on the options page, with the one that is running now marked.

## The decisions

**The two sets are added together, not swapped.** A company freeze and a project's own migration freeze are both true at once, and the longest-running of them decides when deploying resumes.

**Each is read against the timezone its own window is written in**, as a deployment's freezes already were. A global 20 December freezes the Tokyo project by Tokyo's calendar and the London one by London's, which is what each team means by the date.

**In a shared config this is the whole point** — one entry in the team's file and everyone has it.

**Against the shared layer the list behaves as one value**, not as keyed entries, because there is no key to win on. A local list replaces the shared one outright. Concatenating would read better right up until somebody tried to remove a freeze the file had put there and found they could not.

## A required argument, on purpose

`buildTimes` and `statusFor` take the global freezes as a **required** argument. Defaulting it is how the "open now" count would have gone on compiling while reporting a frozen deployment as open — which is exactly what a defaulted argument bought when the days work tried it, so the compiler finds the call sites instead.

The screenshot shows why it mattered: two frozen deployments and **Open now: 0**.

## Two bugs the tests found

Both the same shape — a place that rebuilds the config section by section and silently drops anything new:

* `refreshRemote` rebuilt the cached config from three named sections, so a shared file's `freezes` never reached the cache.
* `Config.save` normalised the same three before splitting, so a locally set list never reached storage.

Neither would have failed a build, a type check or any existing test. Both now carry a comment saying every key of the shape has to be listed here.

## Verification

Full gate green: typecheck, lint, 191 locale messages, **868 unit tests across 29 files**, manifest, bundle, payload (107.9 kB against 128 kB), 36 e2e.

Screenshotted in dark mode against a real loaded extension, with an active freeze and a future one side by side.

## Not in this

**Recurring freezes** — still explicit dates only. "Every year, 20 Dec to 2 Jan" needs a yearless shape and a range that wraps a year, and re-setting the dates each year is arguably the more honest default since they move.
