### PR TITLE
Fail loudly on a dependency known to be broken

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,61 @@
+name: Audit
+
+# Its own workflow rather than a job in ci.yml, for two reasons. It answers a
+# different question - "is anything we depend on known to be broken today" is
+# not "does this change work" - and it needs a trigger the tests do not: an
+# advisory is published by somebody else, on a day when nobody here is pushing
+# anything, and a check that only runs on a push would not hear about it until
+# the next one.
+#
+# Dependabot already opens pull requests for security updates. This is the part
+# that fails loudly in between, and the part that notices an advisory published
+# against a version already installed.
+on:
+  push:
+    branches: [main, '2.x']
+  pull_request:
+  # Tuesday morning, a day after Dependabot's Monday run, so a fix it has
+  # already opened is on the table before this complains about the problem.
+  schedule:
+    - cron: '0 8 * * 2'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  COREPACK_ENABLE_DOWNLOAD_PROMPT: 0
+
+jobs:
+  audit:
+    name: Known vulnerabilities
+    runs-on: ubuntu-latest
+    # Same de-duplication as ci.yml; see the comment there.
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name != github.repository ||
+      !contains(fromJSON('["main", "2.x"]'), github.head_ref)
+
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/setup
+
+      # Anything that reaches a user's browser, at any severity. There are
+      # seven of these and one of them parses notes out of the config, so
+      # "only moderate" is not a reason to ship it.
+      - name: Audit what ships to users
+        run: pnpm audit --prod --audit-level low
+
+      # The build tools, where the bar is higher on purpose. A low-severity
+      # advisory against a test runner is not worth stopping the line for, and
+      # a check that cries wolf is one people learn to ignore - which is how
+      # the 74 alerts this repo used to carry went unread.
+      - name: Audit the build tools
+        run: pnpm audit --audit-level high
+
+      # Reported whatever the result, so a moderate advisory against a dev
+      # dependency is visible in the log without failing the run.
+      - name: Everything known, for the record
+        if: ${{ !cancelled() }}
+        run: pnpm audit || true

--- a/README.md
+++ b/README.md
@@ -189,6 +189,12 @@ Four build checks run in CI and can be run locally:
   total passes its budget, or if `markdown-it` — which the notes render through,
   behind a dynamic import — reappears on that path. One ordinary-looking static
   import puts it back and nothing else would notice.
+* `pnpm check:deps` — known vulnerabilities. Anything that reaches a user's
+  browser fails at any severity; the build tools only at high and above, because
+  a check that cries wolf over a low-severity advisory against a test runner is
+  one people learn to ignore. It runs in its own workflow rather than beside the
+  tests, on a weekly schedule as well as on pushes: an advisory is published by
+  somebody else, on a day when nobody here is pushing anything.
 
 ## Project layout
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "check:locales": "node scripts/check-locales.js",
     "check:manifest": "node scripts/check-manifest.js",
     "check:bundle": "node scripts/check-bundle.js",
-    "check:payload": "node scripts/check-payload.js"
+    "check:payload": "node scripts/check-payload.js",
+    "check:deps": "pnpm audit --prod --audit-level low && pnpm audit --audit-level high"
   },
   "dependencies": {
     "@codemirror/lang-json": "^6.0.2",


### PR DESCRIPTION
The tree is clean and nothing would have noticed if it stopped being — the same gap that let `main` carry 74 alerts for five years.

Dependabot already opens pull requests for security updates. This is the part that fails in between, and the part that hears about an advisory published against a version **already installed**.

## Two invocations, because the two halves deserve different answers

```
pnpm audit --prod --audit-level low    # anything that reaches a browser
pnpm audit --audit-level high          # the build tools
```

**Anything that ships fails at any severity.** There are seven production dependencies and one of them parses notes out of the config — "only moderate" is not a reason to ship it.

**The build tools fail only at high and above.** A low-severity advisory against a test runner is not worth stopping the line for, and a check that cries wolf is one people learn to ignore — which is how those 74 alerts went unread in the first place.

Everything known is printed either way, so a moderate advisory against a dev dependency is visible in the log without being fatal.

## Its own workflow, with a trigger the tests do not have

It answers a different question — "is anything we depend on known to be broken today" is not "does this change work".

And an advisory is published by somebody else, on a day when nobody here is pushing anything, so it runs **weekly** as well as on pushes and PRs. Tuesday morning: a day after Dependabot's Monday run, so a fix it has already opened is on the table before this complains about the problem.

## Reproducible locally

`pnpm check:deps` runs exactly what CI runs. A check you cannot reproduce locally is one you argue with rather than fix.

## Verified by breaking it

```
$ pnpm add -D minimist@0.0.8
$ pnpm audit --audit-level high
│ critical  │ Prototype Pollution in minimist │
2 vulnerabilities found
exit=1

$ pnpm audit --prod --audit-level low
exit=0   ← correctly ignores a dev dependency
```

Both halves do what they claim. The lockfile was restored afterwards.

## Verification

Full gate green: typecheck, lint, 191 locale messages, 868 unit tests across 29 files, and `pnpm check:deps` clean on both invocations.

No source changes — this is CI and a script only.
